### PR TITLE
[Hotfix] typecheking on commit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -53,7 +53,6 @@
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.7.0",
-    "husky": "^3.0.9",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.2",
     "react": "^16.11.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "husky": "^3.0.9",
+    "husky": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
       "git add"
     ],
     "*.{ts,tsx}": [
-      "tsc --noEmit --strict --skipLibCheck",
+      "tsc @tsc.args",
       "git add"
     ],
     "*.{ts,tsx,js,jsx}": [

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,6 @@
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-import": "^2.18.2",
-    "husky": "^3.0.9",
     "lint-staged": "^9.4.3",
     "prettier": "^1.19.1",
     "ts-node": "^8.5.0",

--- a/server/tsc.args
+++ b/server/tsc.args
@@ -1,0 +1,6 @@
+--noEmit
+--strict
+--skipLibCheck
+--pretty
+--experimentalDecorators
+--emitDecoratorMetadata

--- a/yarn.lock
+++ b/yarn.lock
@@ -7212,10 +7212,10 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-husky@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.9.tgz#a2c3e9829bfd6b4957509a9500d2eef5dbfc8044"
-  integrity sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==
+husky@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
+  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
   dependencies:
     chalk "^2.4.2"
     ci-info "^2.0.0"


### PR DESCRIPTION
### 관련 이슈
#68 

### 변경 사항 및 이유
typechecking 시 decorator 사용 옵션을 넣지 않았던 부분을 넣었습니다.

### PR Point
decorator 사용시 type checking 을 통과하지 못하던 부분이 개선되었습니다.

### 참고 사항
tsc command option 에 @ filename 으로 옵션들을 넣을 수 있어서
옵션들을 별도의 파일로 분리하였습니다.