### PR TITLE
[PR] pre-push git hook 에서 test 가 돌도록 함

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage --verbose",
+    "test": "react-scripts test --coverage --verbose --watchAll=false && yarn test:cypress",
+    "test:watch": "react-scripts test --coverage --verbose",
     "test:cypress": "start-server-and-test start http://localhost:3000 cypress",
     "eject": "react-scripts eject",
     "lint": "tsc --noEmit && eslint . --cache --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "precommit:server": "yarn workspace server precommit",
     "precommit:client": "yarn workspace client precommit",
     "precommit": "run-p precommit:server precommit:client",
-    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,scss,css,md}\"",
-    "posttest": "yarn format"
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,scss,css,md}\""
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
   },
   "husky": {
     "hooks": {
-      "precommit": "yarn precommit",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "pre-commit": "yarn precommit",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-push": "yarn test"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     ]
   },
   "scripts": {
+    "test": "run-s test:server test:client",
     "test:server": "yarn workspace server test",
-    "test:client": "yarn workspace client test && yarn workspace client test:cypress",
+    "test:client": "yarn workspace client test",
     "lint": "run-p lint:server lint:client",
     "lint:server": "yarn workspace server lint:fix",
     "lint:client": "yarn workspace client lint:fix",


### PR DESCRIPTION
### 관련 이슈
#123 

### 변경 사항 및 이유
테스트에 통과하지 못한 코드가 푸시되지 않도록 함

### PR Point


### 참고 사항
- 잘 도네요...
- 기존 `client test` 스크립트는 `client test:watch` 로 대체되었습니다
- `client test` 스크립트는 제스트 + 싸이프레스 수행합니다
