### PR TITLE
[이용호] w4_리뷰요청_인피니티 스크롤

### DIFF
--- a/src/components/molecules/Card/index.tsx
+++ b/src/components/molecules/Card/index.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+
+import { EVENT_NAME_MAX_LENGTH } from '../../../commons/constants/number';
+import * as S from './style';
+import Divider from '../../atoms/Divider';
+import { useIntersect } from '../../../hooks';
+
+export interface Props {
+  /** 라우팅 URL */
+  to: string;
+  /** 이벤트 이름 */
+  imgSrc: string;
+  /** 이벤트 날짜 */
+  date: string;
+  /** 이벤트 이름 */
+  title: string;
+  /** 호스트 이름 */
+  host: string;
+  /** 가격 */
+  price: number;
+}
+
+function Card({
+  to,
+  imgSrc,
+  date,
+  title,
+  host,
+  price,
+}: Props): React.ReactElement {
+  /**
+   * 추후에 lazy loading을 포함한 Img Atom Component를 만들 예정
+   * by inthewalter
+   */
+  const [img, setImage] = useState('');
+  const [, setRef] = useIntersect(
+    async (
+      entry: IntersectionObserverEntry,
+      observer: IntersectionObserver,
+    ) => {
+      setImage(imgSrc);
+      observer.unobserve(entry.target);
+    },
+    {
+      threshold: 0.1,
+    },
+  );
+  const eventTitle =
+    title.length >= EVENT_NAME_MAX_LENGTH
+      ? `${title.slice(0, EVENT_NAME_MAX_LENGTH)}...`
+      : title;
+  return (
+    <S.LinkWrapper to={to}>
+      <S.HeaderWrapper></S.HeaderWrapper>
+      <S.ImgDiv imgSrc={img} ref={setRef} />
+      <S.InnerContainer>
+        <S.ContentContainer>
+          <S.Date>{date}</S.Date>
+          <S.Title>{eventTitle}</S.Title>
+          <S.Host>{host}</S.Host>
+        </S.ContentContainer>
+        <S.FooterContainer>
+          <Divider />
+          <S.Price>{price}</S.Price>
+        </S.FooterContainer>
+      </S.InnerContainer>
+    </S.LinkWrapper>
+  );
+}
+
+export default Card;

--- a/src/components/organisms/CardGrid/index.tsx
+++ b/src/components/organisms/CardGrid/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as S from './style';
+import Card from '../../molecules/Card';
+import { Event } from '../../../types/Event';
+
+interface Props {
+  cards: Event[];
+  setRef?: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+}
+
+function CardGrid({ cards, setRef }: Props): React.ReactElement {
+  return (
+    <S.CardGridWrapper>
+      <S.CardGridContainer>
+        {cards.map(card => (
+          <Card
+            key={card.id}
+            imgSrc={card.mainImg}
+            date={card.startAt}
+            title={card.title}
+            host={card.user.lastName + card.user.firstName}
+            price={card.ticketTypes[0].price} // TODO: db 수정 후 바꿔야함
+            to={`/events/${card.id}`}
+          />
+        ))}
+      </S.CardGridContainer>
+      <div ref={setRef}></div>
+    </S.CardGridWrapper>
+  );
+}
+
+export default CardGrid;

--- a/src/hooks/base/useIntersect/index.ts
+++ b/src/hooks/base/useIntersect/index.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface OptionProps {
+  root?: null;
+  threshold?: number;
+  rootMargin?: string;
+}
+
+const baseOption: OptionProps = {
+  root: null,
+  threshold: 0.5,
+  rootMargin: '0px',
+};
+
+export const useIntersect = (
+  onIntersect: (
+    entry: IntersectionObserverEntry,
+    observer: IntersectionObserver,
+  ) => {},
+  option: OptionProps,
+): [
+  HTMLElement | null,
+  React.Dispatch<React.SetStateAction<HTMLElement | null>>,
+] => {
+  const [ref, setRef] = useState<HTMLElement | null>(null);
+  // intersecting이 있을 때 target 엔트리와 observer를 넘겨주자.
+  const checkIntersect = useCallback(
+    ([entry]: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      if (entry.isIntersecting) {
+        onIntersect(entry, observer);
+      }
+    },
+    [onIntersect],
+  );
+  // ref나 option이 바뀔 경우 observer를 새로 등록한다.
+  useEffect(() => {
+    let observer: IntersectionObserver;
+    if (ref) {
+      observer = new IntersectionObserver(checkIntersect, {
+        ...baseOption,
+        ...option,
+      });
+      // start to observe ref
+      observer.observe(ref);
+    }
+    return (): void => observer && observer.disconnect();
+  }, [
+    ref,
+    option.root,
+    option.threshold,
+    option.rootMargin,
+    checkIntersect,
+    option,
+  ]);
+  // setRef를 넘겨주어서 ref를 변경시킬 수 있도록 한다.
+  return [ref, setRef];
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useIntersect } from './base/useIntersect';

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,0 +1,55 @@
+import React, { useState, useCallback } from 'react';
+import axios from 'axios';
+
+import MainTemplate from './template';
+import MainBanner from 'components/organisms/MainBanner';
+import CardGrid from 'components/organisms/CardGrid';
+import { Event } from '../../types/Event';
+import { useIntersect } from '../../hooks';
+
+function Main(): React.ReactElement {
+  const [events, setEvents] = useState<Event[]>([]);
+  const { REACT_APP_SERVER_URL: SERVER_URL } = process.env;
+
+  const delay = (seconds: number): Promise<void> =>
+    new Promise(resolve =>
+      setTimeout(() => {
+        resolve();
+      }, seconds * 1000),
+    );
+
+  const fetchItems = useCallback(async () => {
+    const startAt =
+      events.length === 0
+        ? ''
+        : `&startAt=${events[events.length - 1].startAt}`;
+    const { data } = await axios({
+      method: 'GET',
+      url: `${SERVER_URL}/api/events?cnt=12${startAt}`,
+      withCredentials: true,
+    });
+    await delay(0.5);
+    setEvents([...events, ...data]);
+  }, [events]);
+
+  const [, setRef] = useIntersect(
+    async (
+      entry: IntersectionObserverEntry,
+      observer: IntersectionObserver,
+    ) => {
+      await fetchItems();
+    },
+    {
+      threshold: 1.0,
+    },
+  );
+
+  return (
+    <MainTemplate
+      mainBanner={<MainBanner />}
+      cardGrid={<CardGrid cards={events} setRef={setRef} />}
+    />
+  );
+}
+
+export default Main;


### PR DESCRIPTION
### Review Point

안녕하세요 리뷰어님?
오늘은 infinite scroll을 개발하면서 생긴 이슈에 대해 나누고자 합니다.
IntersectionObeserver API를 사용해서 이미지 리스트의 맨 마지막에 도달하면 추가 데이터를 로딩하는 방식을 도입했습니다.
Hooks를 사용하여 
`setEvents([...events, ...data]);` 이런식으로 추가 데이터를 넣어주고 있는데, 
관련된 리스트가 모두 다시 렌더링이 되는 현상이 있어서
[useCallback](https://ko.reactjs.org/docs/hooks-reference.html#usecallback)을 사용하여 불필요한 렌더링을 방지한 거 같은데(?) 
이렇게 리액트에서 상태를 변경할 때, 배열같은 경우는 새로운 배열을 할당할 수 밖에 없는데 추가 되기 전의 기존 배열의 렌더링을 막기위해선 어떤 방법을 취해야할 지 고민입니다...

### 참고 사항
관련 링크
 - https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
 - https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video