### PR TITLE
[PR] Client import style 변경(YH + JH style)

### DIFF
--- a/client/src/components/atoms/GoogleMap/index.tsx
+++ b/client/src/components/atoms/GoogleMap/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import GoogleMapReact from 'google-map-react';
 
 import * as S from './style';
-import Pin from '../../../assets/img/pin.svg';
+import Pin from 'assets/img/pin.svg';
 
 const {
   REACT_APP_GOOGLE_MAP_API_KEY,
@@ -27,6 +27,7 @@ function GoogleMap({ latitude, longitude }: Props): React.ReactElement {
         center={{ lat: latitude, lng: longitude }}
         defaultCenter={defaultCenter}
         defaultZoom={defaultZoom}
+        draggable={false}
       >
         <S.PinIcon alt={'pin'} height={'3rem'} src={Pin} />
       </GoogleMapReact>

--- a/client/src/components/atoms/GoogleMap/style.ts
+++ b/client/src/components/atoms/GoogleMap/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import Icon from '../Icon';
+import { Icon } from 'components';
 
 export const Container = styled.div`
   width: 100%;

--- a/client/src/components/atoms/Icon/index.spec.tsx
+++ b/client/src/components/atoms/Icon/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Icon from '.';
-import ExternalLinkSymbol from '../../../assets/img/external-link-symbol.svg';
+import ExternalLinkSymbol from 'src/assets/img/external-link-symbol.svg';
 
 describe('Atom / Icon', () => {
   it('[SNAPSHOT] 렌더링', () => {

--- a/client/src/components/atoms/Icon/index.spec.tsx
+++ b/client/src/components/atoms/Icon/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Icon from '.';
-import ExternalLinkSymbol from 'src/assets/img/external-link-symbol.svg';
+import ExternalLinkSymbol from 'assets/img/external-link-symbol.svg';
 
 describe('Atom / Icon', () => {
   it('[SNAPSHOT] 렌더링', () => {

--- a/client/src/components/atoms/Icon/index.stories.tsx
+++ b/client/src/components/atoms/Icon/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { text } from '@storybook/addon-knobs';
 
 import Icon from '.';
-import ExternalLinkSymbol from '../../../assets/img/external-link-symbol.svg';
+import ExternalLinkSymbol from 'assets/img/external-link-symbol.svg';
 
 export default {
   title: 'Atoms / Icon',

--- a/client/src/components/atoms/Icon/index.tsx
+++ b/client/src/components/atoms/Icon/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as S from './style';
 
-export interface IconProps {
+export interface Props {
   /** 접근성 대응 */
   alt: string;
   /** 크기 */
@@ -13,7 +13,7 @@ export interface IconProps {
   circular?: boolean;
 }
 
-function Icon({ height = '2rem', ...props }: IconProps): React.ReactElement {
+function Icon({ height = '2rem', ...props }: Props): React.ReactElement {
   return <S.Img height={height} {...props} />;
 }
 

--- a/client/src/components/atoms/Img/index.tsx
+++ b/client/src/components/atoms/Img/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import * as S from './style';
-import { useIntersect } from '../../../hooks';
+import { useIntersect } from 'hooks';
 
 export interface Props {
   /** alternation img */

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,0 +1,26 @@
+export { default as Btn } from './atoms/Btn';
+export { default as Divider } from './atoms/Divider';
+export { default as EventDate } from './atoms/EventDate';
+export { default as Icon } from './atoms/Icon';
+export { default as GoogleMap } from './atoms/GoogleMap';
+export { default as Img } from './atoms/Img';
+export { default as Input } from './atoms/Input';
+export { default as Label } from './atoms/Label';
+export { default as Price } from './atoms/Price';
+
+export { default as Card } from './molecules/Card';
+export { default as Counter } from './molecules/Counter';
+export { default as FormInput } from './molecules/FormInput';
+export { default as IconBtn } from './molecules/IconBtn';
+export { default as IconLabel } from './molecules/IconLabel';
+export { default as ImgBtn } from './molecules/ImgBtn';
+
+export { default as CardGrid } from './organisms/CardGrid';
+export { default as EventHeader } from './organisms/EventHeader';
+export { default as Footer } from './organisms/Footer';
+export { default as Header } from './organisms/Header';
+export { default as MainBanner } from './organisms/MainBanner';
+export { default as Place } from './organisms/Place';
+export { default as SignUpForm } from './organisms/SignUpForm';
+export { default as Ticket } from './organisms/Ticket';
+export { default as TicketBox } from './organisms/TicketBox';

--- a/client/src/components/molecules/Card/index.tsx
+++ b/client/src/components/molecules/Card/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { EVENT_NAME_MAX_LENGTH } from '../../../commons/constants/number';
+import { EVENT_NAME_MAX_LENGTH } from 'commons/constants/number';
 import * as S from './style';
-import Divider from '../../atoms/Divider';
-import Img from '../../atoms/Img';
+import { Divider, Img } from 'components';
 
 export interface Props {
   /** 라우팅 URL */

--- a/client/src/components/molecules/Counter/index.tsx
+++ b/client/src/components/molecules/Counter/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import * as S from './style';
-import Icon from 'components/atoms/Icon';
+import { Icon } from 'components';
 import LeftArrow from 'assets/img/left-arrow.svg';
 import RightArrow from 'assets/img/right-arrow.svg';
 

--- a/client/src/components/molecules/FormInput/index.tsx
+++ b/client/src/components/molecules/FormInput/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as S from './style';
-import Label, { Props as LabelProps } from '../../atoms/Label';
+import Label, { Props as LabelProps } from 'components/atoms/Label';
 
 export interface Props {
   /** name of input */

--- a/client/src/components/molecules/FormInput/style.ts
+++ b/client/src/components/molecules/FormInput/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ifProp, palette, theme } from 'styled-tools';
-import { Input } from 'components';
+import Input from 'components/atoms/Input';
 
 interface Props {
   invalid?: boolean;

--- a/client/src/components/molecules/FormInput/style.ts
+++ b/client/src/components/molecules/FormInput/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ifProp, palette, theme } from 'styled-tools';
-import Input from '../../atoms/Input';
+import { Input } from 'components';
 
 interface Props {
   invalid?: boolean;

--- a/client/src/components/molecules/IconBtn/index.spec.tsx
+++ b/client/src/components/molecules/IconBtn/index.spec.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import IconBtn from '.';
-import ExternalLinkSymbol from '../../../assets/img/external-link-black.svg';
-import ExternalLinkSymbolColored from '../../../assets/img/external-link-colored.svg';
+import ExternalLinkSymbol from 'assets/img/external-link-black.svg';
+import ExternalLinkSymbolColored from 'assets/img/external-link-colored.svg';
 const tempCircleImgSrc =
   'https://cf.festa.io/default-images/host-profiles/Profile-00047.jpg';
 

--- a/client/src/components/molecules/IconBtn/index.stories.tsx
+++ b/client/src/components/molecules/IconBtn/index.stories.tsx
@@ -3,8 +3,8 @@ import { text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import IconBtn from '.';
-import ExternalLinkSymbol from '../../../assets/img/external-link-black.svg';
-import ExternalLinkSymbolColored from '../../../assets/img/external-link-colored.svg';
+import ExternalLinkSymbol from 'assets/img/external-link-black.svg';
+import ExternalLinkSymbolColored from 'assets/img/external-link-colored.svg';
 const tempCircleImgSrc =
   'https://cf.festa.io/default-images/host-profiles/Profile-00047.jpg';
 

--- a/client/src/components/molecules/IconBtn/style.ts
+++ b/client/src/components/molecules/IconBtn/style.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { ifProp } from 'styled-tools';
 
-import { BtnStyle } from '../../atoms/Btn/style';
-import Icon from '../../atoms/Icon';
+import { BtnStyle } from 'components/atoms/Btn/style';
+import { Icon } from 'components';
 
 interface ContainerProps {
   fullid: boolean;

--- a/client/src/components/molecules/IconBtn/style.ts
+++ b/client/src/components/molecules/IconBtn/style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { ifProp } from 'styled-tools';
 
 import { BtnStyle } from 'components/atoms/Btn/style';
-import { Icon } from 'components';
+import Icon from 'components/atoms/Icon';
 
 interface ContainerProps {
   fullid: boolean;

--- a/client/src/components/molecules/IconLabel/index.spec.tsx
+++ b/client/src/components/molecules/IconLabel/index.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import IconLabel from '.';
-import Check from '../../../assets/img/check-black.svg';
+import Check from 'assets/img/check-black.svg';
 
 describe('Atom / IconBtn', () => {
   it('[SNAPSHOT] 렌더링', () => {

--- a/client/src/components/molecules/IconLabel/index.stories.tsx
+++ b/client/src/components/molecules/IconLabel/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { text, object } from '@storybook/addon-knobs';
 
 import IconLabel from '.';
-import Check from '../../../assets/img/check-black.svg';
+import Check from 'assets/img/check-black.svg';
 
 export default {
   title: 'Molecules / IconLabel',

--- a/client/src/components/molecules/IconLabel/index.tsx
+++ b/client/src/components/molecules/IconLabel/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import Icon, { IconProps } from '../../atoms/Icon';
+import Icon, { Props as IconProps } from 'components/atoms/Icon';
 
 export interface IconLabelProps {
   iconProps: IconProps;

--- a/client/src/components/molecules/ImgBtn/index.tsx
+++ b/client/src/components/molecules/ImgBtn/index.tsx
@@ -15,9 +15,9 @@ interface Props {
 
 function ImgBtn({ src, alt, ...props }: Props): React.ReactElement {
   return (
-    <S.Btn {...props}>
-      <S.Img alt={alt} src={src} />
-    </S.Btn>
+    <S.Button {...props}>
+      <S.Image alt={alt} src={src} />
+    </S.Button>
   );
 }
 

--- a/client/src/components/molecules/ImgBtn/style.ts
+++ b/client/src/components/molecules/ImgBtn/style.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import { palette } from 'styled-tools';
 
-import { Btn, Img } from 'components';
+import Btn from 'components/atoms/Btn';
+import Img from 'components/atoms/Img';
 
 export const Button = styled(Btn)`
   display: flex;

--- a/client/src/components/molecules/ImgBtn/style.ts
+++ b/client/src/components/molecules/ImgBtn/style.ts
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
 import { palette } from 'styled-tools';
 
-import Button from '../../atoms/Btn';
-import Image from '../../atoms/Img';
+import { Btn, Img } from 'components';
 
-export const Btn = styled(Button)`
+export const Button = styled(Btn)`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -14,7 +13,7 @@ export const Btn = styled(Button)`
   padding: 0;
 `;
 
-export const Img = styled(Image)`
+export const Image = styled(Img)`
   &:hover {
     opacity: ${palette('opacityscale', 1)};
     transition: opacity 1s;

--- a/client/src/components/organisms/CardGrid/index.stories.tsx
+++ b/client/src/components/organisms/CardGrid/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import CardGrid from '.';
-import { Event } from '../../../types/Event';
+import { Event } from 'types/Event';
 
 export default {
   title: 'Organisms / CardGrid',

--- a/client/src/components/organisms/CardGrid/index.tsx
+++ b/client/src/components/organisms/CardGrid/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import Card from 'components/molecules/Card';
+import { Card } from 'components';
 import { Event } from 'types/Event';
 import ROUTES from 'commons/constants/routes';
 

--- a/client/src/components/organisms/EventHeader/index.tsx
+++ b/client/src/components/organisms/EventHeader/index.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
 import * as S from './style';
-import Icon from '../../atoms/Icon';
-import IconBtn from '../../molecules/IconBtn';
-import Price from '../../atoms/Price';
-import { User, TicketType } from '../../../types/Data';
+import { Icon, IconBtn, Price } from 'components';
+import { User, TicketType } from 'types/Data';
 
-import MultipleUsers from '../../../assets/img/multiple-users-silhouette.svg';
-import ExternalSymbolBlack from '../../../assets/img/external-link-black.svg';
-import ExternalSymbolColored from '../../../assets/img/external-link-colored.svg';
+import MultipleUsers from 'assets/img/multiple-users-silhouette.svg';
+import ExternalSymbolBlack from 'assets/img/external-link-black.svg';
+import ExternalSymbolColored from 'assets/img/external-link-colored.svg';
 
 interface Props {
   mainImg: string;

--- a/client/src/components/organisms/EventHeader/style.ts
+++ b/client/src/components/organisms/EventHeader/style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { prop, theme, palette } from 'styled-tools';
 
-import Btn from '../../atoms/Btn';
+import { Btn } from 'components';
 
 export const Container = styled.div``;
 

--- a/client/src/components/organisms/Footer/index.tsx
+++ b/client/src/components/organisms/Footer/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import * as S from './style';
-import logoGray from '../../../assets/img/logo-gray.svg';
-import { FOOTER_INFO } from '../../../commons/constants/string';
-import Divider from '../../atoms/Divider';
+import logoGray from 'assets/img/logo-gray.svg';
+import { FOOTER_INFO } from 'commons/constants/string';
+import { Divider } from 'components';
 
 function Footer(): React.ReactElement {
   return (

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
 
 import * as S from './style';
-import Btn from '../../atoms/Btn';
-import logo from '../../../assets/img/logo.svg';
-import ROUTES from '../../../commons/constants/routes';
-import { CREATE_EVENT } from '../../../commons/constants/string';
+import { Btn } from 'components';
+import logo from 'assets/img/logo.svg';
+import ROUTES from 'commons/constants/routes';
+import { CREATE_EVENT } from 'commons/constants/string';
 
-import { UserAccountState } from '../../../stores/accountStore';
+import { UserAccountState } from 'stores/accountStore';
 
 function Header(): React.ReactElement {
   const account = useContext(UserAccountState);

--- a/client/src/components/organisms/Header/style.ts
+++ b/client/src/components/organisms/Header/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import ImgBtn from '../../molecules/ImgBtn';
+import { ImgBtn } from 'components';
 
 export const Container = styled.div`
   width: 100%;

--- a/client/src/components/organisms/MainBanner/index.tsx
+++ b/client/src/components/organisms/MainBanner/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as S from './style';
-import Btn from 'components/atoms/Btn';
+import { Btn } from 'components';
 import { CREATE_EVENT } from 'commons/constants/string';
 import ROUTES from 'commons/constants/routes';
 

--- a/client/src/components/organisms/Place/index.tsx
+++ b/client/src/components/organisms/Place/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as S from './style';
 import { Location } from 'types/Data';
-import GoogleMap from '../../atoms/GoogleMap';
+import { GoogleMap } from 'components';
 
 interface Props {
   place: string;

--- a/client/src/components/organisms/SignUpForm/index.stories.tsx
+++ b/client/src/components/organisms/SignUpForm/index.stories.tsx
@@ -9,7 +9,7 @@ import {
   SIGNUP_LAST_NAME,
   SIGNUP_PHONE_NUMBER,
   SIGNUP_PASSSWORD,
-} from '../../../commons/constants/string';
+} from 'commons/constants/string';
 
 export default {
   title: 'Organisms / SignUpForm',

--- a/client/src/components/organisms/SignUpForm/index.tsx
+++ b/client/src/components/organisms/SignUpForm/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import * as S from './style';
-import FormInput, { Props as FormInputProps } from '../../molecules/FormInput';
-import Btn, { Props as BtnProps } from '../../atoms/Btn';
+import FormInput, {
+  Props as FormInputProps,
+} from 'components/molecules/FormInput';
+import Btn, { Props as BtnProps } from 'components/atoms/Btn';
 
 export interface Props {
   FormInputs: {

--- a/client/src/components/organisms/SignUpForm/style.ts
+++ b/client/src/components/organisms/SignUpForm/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ifProp, palette, theme } from 'styled-tools';
-import Input from '../../atoms/Input';
+import { Input } from 'components';
 
 interface Props {
   invalid?: boolean;

--- a/client/src/components/organisms/Ticket/__snapshots__/indes.spec.tsx.snap
+++ b/client/src/components/organisms/Ticket/__snapshots__/indes.spec.tsx.snap
@@ -32,6 +32,10 @@ exports[`Organisms / Ticket Rendering 1`] = `
   margin: 2rem 0rem;
 }
 
+.c7 {
+  height: 1.5rem;
+}
+
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -45,10 +49,6 @@ exports[`Organisms / Ticket Rendering 1`] = `
 
 .c8 {
   margin-left: 1rem;
-}
-
-.c7 {
-  height: 1.5rem;
 }
 
 <Ticket
@@ -219,15 +219,15 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "$$typeof": Symbol(react.forward_ref),
                               "attrs": Array [],
                               "componentStyle": ComponentStyle {
-                                "componentId": "sc-dnqmqq",
+                                "componentId": "sc-cSHVUG",
                                 "isStatic": false,
-                                "lastClassName": "bDsesi",
+                                "lastClassName": "CAuLq",
                                 "rules": Array [],
                               },
                               "displayName": "styled.div",
                               "foldedComponentIds": Array [],
                               "render": [Function],
-                              "styledComponentId": "sc-dnqmqq",
+                              "styledComponentId": "sc-cSHVUG",
                               "target": "div",
                               "toString": [Function],
                               "warnTooManyClasses": [Function],
@@ -340,7 +340,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "$$typeof": Symbol(react.forward_ref),
                         "attrs": Array [],
                         "componentStyle": ComponentStyle {
-                          "componentId": "sc-bZQynM",
+                          "componentId": "sc-iRbamj",
                           "isStatic": false,
                           "lastClassName": "c6",
                           "rules": Array [
@@ -354,7 +354,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "displayName": "styled.div",
                         "foldedComponentIds": Array [],
                         "render": [Function],
-                        "styledComponentId": "sc-bZQynM",
+                        "styledComponentId": "sc-iRbamj",
                         "target": "div",
                         "toString": [Function],
                         "warnTooManyClasses": [Function],
@@ -383,7 +383,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "$$typeof": Symbol(react.forward_ref),
                                 "attrs": Array [],
                                 "componentStyle": ComponentStyle {
-                                  "componentId": "sc-htoDjs",
+                                  "componentId": "sc-gZMcBi",
                                   "isStatic": false,
                                   "lastClassName": "c7",
                                   "rules": Array [
@@ -400,7 +400,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "displayName": "styled.img",
                                 "foldedComponentIds": Array [],
                                 "render": [Function],
-                                "styledComponentId": "sc-htoDjs",
+                                "styledComponentId": "sc-gZMcBi",
                                 "target": "img",
                                 "toString": [Function],
                                 "warnTooManyClasses": [Function],
@@ -427,7 +427,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "$$typeof": Symbol(react.forward_ref),
                               "attrs": Array [],
                               "componentStyle": ComponentStyle {
-                                "componentId": "sc-gzVnrw",
+                                "componentId": "sc-jlyJG",
                                 "isStatic": false,
                                 "lastClassName": "c8",
                                 "rules": Array [
@@ -442,7 +442,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "displayName": "styled.div",
                               "foldedComponentIds": Array [],
                               "render": [Function],
-                              "styledComponentId": "sc-gzVnrw",
+                              "styledComponentId": "sc-jlyJG",
                               "target": "div",
                               "toString": [Function],
                               "warnTooManyClasses": [Function],
@@ -479,7 +479,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "$$typeof": Symbol(react.forward_ref),
                         "attrs": Array [],
                         "componentStyle": ComponentStyle {
-                          "componentId": "sc-bZQynM",
+                          "componentId": "sc-iRbamj",
                           "isStatic": false,
                           "lastClassName": "c6",
                           "rules": Array [
@@ -493,7 +493,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "displayName": "styled.div",
                         "foldedComponentIds": Array [],
                         "render": [Function],
-                        "styledComponentId": "sc-bZQynM",
+                        "styledComponentId": "sc-iRbamj",
                         "target": "div",
                         "toString": [Function],
                         "warnTooManyClasses": [Function],
@@ -522,7 +522,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "$$typeof": Symbol(react.forward_ref),
                                 "attrs": Array [],
                                 "componentStyle": ComponentStyle {
-                                  "componentId": "sc-htoDjs",
+                                  "componentId": "sc-gZMcBi",
                                   "isStatic": false,
                                   "lastClassName": "c7",
                                   "rules": Array [
@@ -539,7 +539,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "displayName": "styled.img",
                                 "foldedComponentIds": Array [],
                                 "render": [Function],
-                                "styledComponentId": "sc-htoDjs",
+                                "styledComponentId": "sc-gZMcBi",
                                 "target": "img",
                                 "toString": [Function],
                                 "warnTooManyClasses": [Function],
@@ -566,7 +566,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "$$typeof": Symbol(react.forward_ref),
                               "attrs": Array [],
                               "componentStyle": ComponentStyle {
-                                "componentId": "sc-gzVnrw",
+                                "componentId": "sc-jlyJG",
                                 "isStatic": false,
                                 "lastClassName": "c8",
                                 "rules": Array [
@@ -581,7 +581,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "displayName": "styled.div",
                               "foldedComponentIds": Array [],
                               "render": [Function],
-                              "styledComponentId": "sc-gzVnrw",
+                              "styledComponentId": "sc-jlyJG",
                               "target": "div",
                               "toString": [Function],
                               "warnTooManyClasses": [Function],
@@ -618,7 +618,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "$$typeof": Symbol(react.forward_ref),
                         "attrs": Array [],
                         "componentStyle": ComponentStyle {
-                          "componentId": "sc-bZQynM",
+                          "componentId": "sc-iRbamj",
                           "isStatic": false,
                           "lastClassName": "c6",
                           "rules": Array [
@@ -632,7 +632,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                         "displayName": "styled.div",
                         "foldedComponentIds": Array [],
                         "render": [Function],
-                        "styledComponentId": "sc-bZQynM",
+                        "styledComponentId": "sc-iRbamj",
                         "target": "div",
                         "toString": [Function],
                         "warnTooManyClasses": [Function],
@@ -661,7 +661,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "$$typeof": Symbol(react.forward_ref),
                                 "attrs": Array [],
                                 "componentStyle": ComponentStyle {
-                                  "componentId": "sc-htoDjs",
+                                  "componentId": "sc-gZMcBi",
                                   "isStatic": false,
                                   "lastClassName": "c7",
                                   "rules": Array [
@@ -678,7 +678,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                                 "displayName": "styled.img",
                                 "foldedComponentIds": Array [],
                                 "render": [Function],
-                                "styledComponentId": "sc-htoDjs",
+                                "styledComponentId": "sc-gZMcBi",
                                 "target": "img",
                                 "toString": [Function],
                                 "warnTooManyClasses": [Function],
@@ -705,7 +705,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "$$typeof": Symbol(react.forward_ref),
                               "attrs": Array [],
                               "componentStyle": ComponentStyle {
-                                "componentId": "sc-gzVnrw",
+                                "componentId": "sc-jlyJG",
                                 "isStatic": false,
                                 "lastClassName": "c8",
                                 "rules": Array [
@@ -720,7 +720,7 @@ exports[`Organisms / Ticket Rendering 1`] = `
                               "displayName": "styled.div",
                               "foldedComponentIds": Array [],
                               "render": [Function],
-                              "styledComponentId": "sc-gzVnrw",
+                              "styledComponentId": "sc-jlyJG",
                               "target": "div",
                               "toString": [Function],
                               "warnTooManyClasses": [Function],

--- a/client/src/components/organisms/Ticket/index.tsx
+++ b/client/src/components/organisms/Ticket/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import * as S from './style';
-import { TicketType } from '../../../types/Data';
-import IconLabel from '../../molecules/IconLabel';
+import { TicketType } from 'types/Data';
+import { IconLabel, Price } from 'components';
 
-import MultipleUsers from '../../../assets/img/multiple-users-silhouette.svg';
-import Check from '../../../assets/img/check-black.svg';
-import Calendar from '../../../assets/img/calendar-black.svg';
-import Price from '../../atoms/Price';
+import MultipleUsers from 'assets/img/multiple-users-silhouette.svg';
+import Check from 'assets/img/check-black.svg';
+import Calendar from 'assets/img/calendar-black.svg';
 
 function Ticket({
   price,

--- a/client/src/components/organisms/TicketBox/index.tsx
+++ b/client/src/components/organisms/TicketBox/index.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import * as S from './style';
 import TicketImg from 'assets/img/ticket.svg';
-import IconLabel from 'components/molecules/IconLabel';
-import Price from 'components/atoms/Price';
+import { IconLabel, Price } from 'components';
 import { TicketType } from 'types/Data';
 import { calculateDiffDaysOfDateRange } from 'utils/dateCalculator';
 

--- a/client/src/hooks/meta/accountReducer/index.ts
+++ b/client/src/hooks/meta/accountReducer/index.ts
@@ -1,5 +1,5 @@
-import { AccountState } from '../../../types/States';
-import { AccountAction } from '../../../types/Actions';
+import { AccountState } from 'types/States';
+import { AccountAction } from 'types/Actions';
 
 export const defaultAccountState: AccountState = {
   isLogin: false,

--- a/client/src/pages/BasedTemplate/templates/index.stories.tsx
+++ b/client/src/pages/BasedTemplate/templates/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import BasedTemplate from '../templates';
+import BasedTemplate from 'pages/BasedTemplate/templates';
 
 export default {
   title: 'Templates / BasedTemplate',

--- a/client/src/pages/BasedTemplate/templates/index.tsx
+++ b/client/src/pages/BasedTemplate/templates/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import Header from '../../../components/organisms/Header';
-import Footer from '../../../components/organisms/Footer';
+import { Header, Footer } from 'components';
 
 interface Props {
   children: React.ReactNode;

--- a/client/src/pages/EventDetail/store.tsx
+++ b/client/src/pages/EventDetail/store.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useReducer, Dispatch } from 'react';
 
-import { useStateReducer } from '../../hooks/base/useStateReduter';
-import { UseStateReducer } from '../../types/CustomHooks';
-import { ActionParams } from '../../types/Actions';
-import { EventDetailState } from '../../types/States';
+import { useStateReducer } from 'hooks/base/useStateReduter';
+import { UseStateReducer } from 'types/CustomHooks';
+import { ActionParams } from 'types/Actions';
+import { EventDetailState } from 'types/States';
 
 const defaultState: EventDetailState = {
   eventData: {

--- a/client/src/pages/EventDetail/template/index.tsx
+++ b/client/src/pages/EventDetail/template/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import BasedTemplate from '../../BasedTemplate/templates';
+import BasedTemplate from 'pages/BasedTemplate/templates';
 
 interface Props {
   eventHeader: React.ReactNode;

--- a/client/src/pages/EventDetail/view.tsx
+++ b/client/src/pages/EventDetail/view.tsx
@@ -1,12 +1,10 @@
 import React, { useContext, useEffect } from 'react';
 import EventDetailTemplate from './template';
-import EventHeader from 'components/organisms/EventHeader';
-import Ticket from 'components/organisms/Ticket';
-import Place from 'components/organisms/Place';
+import { Place, Ticket, EventHeader } from 'components';
 
 import { EventDataAction, EventDataState } from './store';
-import { useFetch } from '../../hooks/base/useFetch';
-import { EventDetail } from '../../types/Data';
+import { useFetch } from 'hooks/base/useFetch';
+import { EventDetail } from 'types/Data';
 
 const { REACT_APP_SERVER_URL } = process.env;
 interface Props {

--- a/client/src/pages/EventJoin/template/index.tsx
+++ b/client/src/pages/EventJoin/template/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import BasedTemplate from '../../BasedTemplate/templates';
+import BasedTemplate from 'pages/BasedTemplate/templates';
 
 interface Props {
   TicketHeader: React.ReactNode;

--- a/client/src/pages/EventJoin/view.tsx
+++ b/client/src/pages/EventJoin/view.tsx
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 
 import EventJoinTemplate from './template';
-import TicketBox from 'components/organisms/TicketBox';
-import Counter from 'components/molecules/Counter';
-import Btn from 'components/atoms/Btn';
+import { Btn, Counter, TicketBox } from 'components';
 import * as S from './style';
 import { useHistory } from 'react-router-dom';
 import httpStatus from 'http-status';

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import * as S from './style';
-import IconBtn from '../../components/molecules/IconBtn';
-import { OAUTH_GOOGLE, LOGIN_SOCIAL } from '../../commons/constants/string';
-import googleSvg from '../../assets/img/google.svg';
-import LogoSvg from '../../assets/img/logo.svg';
+import { IconBtn } from 'components';
+import { OAUTH_GOOGLE, LOGIN_SOCIAL } from 'commons/constants/string';
+import googleSvg from 'assets/img/google.svg';
+import LogoSvg from 'assets/img/logo.svg';
 import LoginTemplate from './templates';
 
 const { REACT_APP_SERVER_URL } = process.env;

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -2,11 +2,10 @@ import React, { useState, useCallback } from 'react';
 import axios from 'axios';
 
 import MainTemplate from './template';
-import MainBanner from 'components/organisms/MainBanner';
-import CardGrid from 'components/organisms/CardGrid';
-import { Event } from '../../types/Event';
-import { useIntersect } from '../../hooks';
-import delay from '../../utils/delay';
+import { MainBanner, CardGrid } from 'components';
+import { Event } from 'types/Event';
+import { useIntersect } from 'hooks';
+import delay from 'utils/delay';
 
 function Main(): React.ReactElement {
   const [events, setEvents] = useState<Event[]>([]);

--- a/client/src/pages/Main/template/index.tsx
+++ b/client/src/pages/Main/template/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as S from './style';
-import BasedTemplate from '../../BasedTemplate/templates';
+import BasedTemplate from 'pages/BasedTemplate/templates';
 
 interface Props {
   mainBanner: React.ReactNode;

--- a/client/src/pages/NotFound/index.tsx
+++ b/client/src/pages/NotFound/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import NotFoundTemplate from './template';
-import ImgBtn from 'components/molecules/ImgBtn';
+import { ImgBtn } from 'components';
 import ROUTES from 'commons/constants/routes';
 
 function NotFound(): React.ReactElement {

--- a/client/src/pages/SignUp/store.tsx
+++ b/client/src/pages/SignUp/store.tsx
@@ -8,13 +8,13 @@ import React, {
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 
-import { useStateReducer } from '../../hooks/base/useStateReduter';
-import { ActionParams } from '../../types/Actions';
-import { SignUpFormState } from '../../types/States';
-import { UseStateReducer } from '../../types/CustomHooks';
-import { validatePhoneNumber, validateName } from '../../utils/validateInput';
+import { useStateReducer } from 'hooks/base/useStateReduter';
+import { ActionParams } from 'types/Actions';
+import { SignUpFormState } from 'types/States';
+import { UseStateReducer } from 'types/CustomHooks';
+import { validatePhoneNumber, validateName } from 'utils/validateInput';
 
-import { UserAccountState, UserAccountAction } from '../../stores/accountStore';
+import { UserAccountState, UserAccountAction } from 'stores/accountStore';
 
 const { REACT_APP_SERVER_URL } = process.env;
 

--- a/client/src/pages/SignUp/view.tsx
+++ b/client/src/pages/SignUp/view.tsx
@@ -1,11 +1,10 @@
 import React, { useContext } from 'react';
 import SignUpTemplate from './template';
-import SignUpForm from '../../components/organisms/SignUpForm';
-import ImgBtn from '../../components/molecules/ImgBtn';
-import logo from '../../assets/img/logo.svg';
-import ROUTES from '../../commons/constants/routes';
+import { SignUpForm, ImgBtn } from 'components';
+import logo from 'assets/img/logo.svg';
+import ROUTES from 'commons/constants/routes';
 import { SignUpAction, SignUpState } from './store';
-import { UserAccountState } from '../../stores/accountStore';
+import { UserAccountState } from 'stores/accountStore';
 
 import {
   SIGNUP_EMAIL,
@@ -13,7 +12,7 @@ import {
   SIGNUP_LAST_NAME,
   SIGNUP_PHONE_NUMBER,
   SIGNUP_BTN,
-} from '../../commons/constants/string';
+} from 'commons/constants/string';
 
 function SignUpView(): React.ReactElement {
   const { email } = useContext(UserAccountState);

--- a/client/src/stores/accountStore.tsx
+++ b/client/src/stores/accountStore.tsx
@@ -8,10 +8,10 @@ import React, {
 } from 'react';
 import axios from 'axios';
 
-import { AccountAction } from '../types/Actions';
-import { AccountState } from '../types/States';
-import { AccountReducer } from '../types/CustomHooks';
-import { accountReducer, defaultAccountState } from '../hooks';
+import { AccountAction } from 'types/Actions';
+import { AccountState } from 'types/States';
+import { AccountReducer } from 'types/CustomHooks';
+import { accountReducer, defaultAccountState } from 'hooks';
 
 const { REACT_APP_SERVER_URL } = process.env;
 

--- a/client/src/types/States.ts
+++ b/client/src/types/States.ts
@@ -1,4 +1,4 @@
-import { EventDetail } from '../types/Data';
+import { EventDetail } from 'types/Data';
 
 export interface SignUpFormState {
   lastName: string;


### PR DESCRIPTION
### 관련 이슈

#246 
#37 

### 변경 사항 및 이유

client 디렉토리 구조 depth 개선
코드의 간결함과 편리함을 높임

### PR Point

[client/src/components/index.ts](https://github.com/connect-foundation/2019-12/compare/develop...feature-246?expand=1#diff-09788d095c50625f117aa2d658f9af30)

### 참고 사항

- components/index.ts 에서 항상 atom -> molecules -> organisms 순서로 import를 해야합니다. 그래야만 상위 컴포넌트에서 하위 컴포넌트를 import 할 수 있습니다.
- molecules 단계에서는`import { 컴포넌트 } from 'components'`를 사용해선 안됩니다. 왜냐하면 oraganisms에서 molecules 를` import { molecuels 컴포넌트 } from 'components'`를 하게되면 원형참조가 일어나서 undefined를 반환합니다. organisms 레벨 이상에선 사용해도 됩니다! [관련 이슈](https://github.com/styled-components/styled-components/issues/1449#issuecomment-360503586)
### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
