### PR TITLE
[PR] GET /api/events/:eventId/users 이벤트의 참여자들의 리스트를 불러오는 API

### DIFF
--- a/server/src/routes/api/events/controllers/getAttendants.ts
+++ b/server/src/routes/api/events/controllers/getAttendants.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import { BAD_REQUEST, NO_CONTENT } from 'http-status';
+import { getUserTicketsByTicketId } from 'services';
+
+export async function getAttendants(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    if (!req.event || !req.user) throw new Error('middleware error');
+    if (req.event.userId !== req.user.id) return res.sendStatus(BAD_REQUEST);
+    const userTickets = await getUserTicketsByTicketId(req.event.ticketType.id);
+    if (!userTickets.length) return res.sendStatus(NO_CONTENT);
+    res.send(userTickets);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/server/src/routes/api/events/controllers/getAttendants.ts
+++ b/server/src/routes/api/events/controllers/getAttendants.ts
@@ -2,14 +2,10 @@ import { Request, Response, NextFunction } from 'express';
 import { BAD_REQUEST, NO_CONTENT } from 'http-status';
 import { getUserTicketsByTicketId } from 'services';
 
-export async function getAttendants(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+export default async function(req: Request, res: Response, next: NextFunction) {
+  if (!req.event || !req.user) throw new Error('middleware error');
+  if (req.event.userId !== req.user.id) return res.sendStatus(BAD_REQUEST);
   try {
-    if (!req.event || !req.user) throw new Error('middleware error');
-    if (req.event.userId !== req.user.id) return res.sendStatus(BAD_REQUEST);
     const userTickets = await getUserTicketsByTicketId(req.event.ticketType.id);
     if (!userTickets.length) return res.sendStatus(NO_CONTENT);
     res.send(userTickets);

--- a/server/src/routes/api/events/controllers/index.ts
+++ b/server/src/routes/api/events/controllers/index.ts
@@ -2,4 +2,4 @@ export { default as getEvents } from './getEvents';
 export { default as getEvent } from './getEvent';
 export { default as getEventTickets } from './getEventTickets';
 export { default as convertPlaceToCoordinate } from './convertPlaceToCoordinate';
-export { getAttendants } from './getAttendants';
+export { default as getAttendants } from './getAttendants';

--- a/server/src/routes/api/events/controllers/index.ts
+++ b/server/src/routes/api/events/controllers/index.ts
@@ -2,3 +2,4 @@ export { default as getEvents } from './getEvents';
 export { default as getEvent } from './getEvent';
 export { default as getEventTickets } from './getEventTickets';
 export { default as convertPlaceToCoordinate } from './convertPlaceToCoordinate';
+export { getAttendants } from './getAttendants';

--- a/server/src/routes/api/events/index.ts
+++ b/server/src/routes/api/events/index.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import * as controllers from './controllers';
 import * as validators from './validators';
 import * as middlewares from './middlewares';
+import { requireLogin } from 'routes/middlewares';
 import { badRequestHandler } from 'utils/errorHandler';
 
 const router = Router();
@@ -12,5 +13,6 @@ router.get('/', validators.getEvents, badRequestHandler, controllers.getEvents);
 router.get('/coordinate', controllers.convertPlaceToCoordinate);
 router.get('/:eventId', controllers.getEvent);
 router.get('/:eventId/tickets', controllers.getEventTickets);
+router.get('/:eventId/users', requireLogin, controllers.getAttendants);
 
 export default router;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,2 +1,6 @@
 export { getUserById, getUserByGoogleId, setUser, setUserInfo } from './users';
-export { getUserTicketsByUserId, deleteUserTicketById } from './userTickets';
+export {
+  getUserTicketsByUserId,
+  getUserTicketsByTicketId,
+  deleteUserTicketById,
+} from './userTickets';

--- a/server/src/services/userTickets.ts
+++ b/server/src/services/userTickets.ts
@@ -20,15 +20,15 @@ function eventTicketReducer(
   cur: UserTicket,
 ): AttendantTicket[] {
   const { user, ...userTicket } = cur.get({ plain: true }) as UserTicket;
-  let data = acc.findIndex(a => a.id === user.id);
-  if (data === -1) {
+  let userIndex = acc.findIndex(user => user.id === user.id);
+  if (userIndex === -1) {
     acc.push({
       ...user,
       userTickets: [],
     });
-    data = acc.length - 1;
+    userIndex = acc.length - 1;
   }
-  acc[data].userTickets.push(userTicket);
+  acc[userIndex].userTickets.push(userTicket);
   return acc;
 }
 function userTicketReducer(acc: BoughtEvent[], cur: UserTicket): BoughtEvent[] {
@@ -36,16 +36,16 @@ function userTicketReducer(acc: BoughtEvent[], cur: UserTicket): BoughtEvent[] {
     ticketType: { event, ...ticketTypes },
     ...userTicket
   } = cur.get({ plain: true }) as UserTicket;
-  let data = acc.findIndex(a => a.id === cur.ticketType.eventId);
-  if (data === -1) {
+  let eventIndex = acc.findIndex(event => event.id === cur.ticketType.eventId);
+  if (eventIndex === -1) {
     acc.push({
       ...event,
       ticket: ticketTypes,
       userTickets: [],
     });
-    data = acc.length - 1;
+    eventIndex = acc.length - 1;
   }
-  acc[data].userTickets.push(userTicket);
+  acc[eventIndex].userTickets.push(userTicket);
   return acc;
 }
 

--- a/server/test/api/__snapshots__/event.spec.ts.snap
+++ b/server/test/api/__snapshots__/event.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GET /api/events/:eventId/users 내 이벤트에 접근한 경우 200 1`] = `
+Array [
+  Object {
+    "email": "sdong001@gmail.com",
+    "firstName": "성동",
+    "id": 2,
+    "lastName": "조",
+    "phoneNumber": "01012341234",
+    "userTickets": Array [
+      Object {
+        "createdAt": "2019-12-10T04:54:17.000Z",
+        "id": 1,
+        "isAttendance": true,
+        "ticketTypeId": 2,
+        "userId": 2,
+      },
+    ],
+  },
+]
+`;

--- a/server/test/api/__snapshots__/event.spec.ts.snap
+++ b/server/test/api/__snapshots__/event.spec.ts.snap
@@ -1,22 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GET /api/events/:eventId/users 내 이벤트에 접근한 경우 200 1`] = `
-Array [
-  Object {
-    "email": "sdong001@gmail.com",
-    "firstName": "성동",
-    "id": 2,
-    "lastName": "조",
-    "phoneNumber": "01012341234",
-    "userTickets": Array [
-      Object {
-        "createdAt": "2019-12-10T04:54:17.000Z",
-        "id": 1,
-        "isAttendance": true,
-        "ticketTypeId": 2,
-        "userId": 2,
-      },
-    ],
-  },
-]
+Object {
+  "email": "sdong001@gmail.com",
+  "firstName": "성동",
+  "id": 2,
+  "lastName": "조",
+  "phoneNumber": "01012341234",
+}
+`;
+
+exports[`GET /api/events/:eventId/users 내 이벤트에 접근한 경우 200 2`] = `
+Object {
+  "id": 1,
+  "isAttendance": true,
+  "ticketTypeId": 2,
+  "userId": 2,
+}
 `;

--- a/server/test/api/event.spec.ts
+++ b/server/test/api/event.spec.ts
@@ -166,7 +166,11 @@ describe('GET /api/events/:eventId/users', () => {
       .set(setHeader(token))
       .expect(OK)
       .expect(res => {
-        expect(res.body).toMatchSnapshot();
+        const data = res.body[0];
+        const { userTickets, ...body } = data;
+        const { createdAt, ...userTicket } = userTickets[0];
+        expect(body).toMatchSnapshot();
+        expect(userTicket).toMatchSnapshot();
       });
   });
 });

--- a/server/test/api/event.spec.ts
+++ b/server/test/api/event.spec.ts
@@ -1,8 +1,24 @@
+import '../../src/env';
 import * as request from 'supertest';
 import app from '../../src/app';
+import { Secret } from 'jsonwebtoken';
+import { generateJWT } from '../../src/utils/jwt';
 import { sequelize } from '../../src/utils/sequelize';
 import { Event } from '../../src/models';
-import { OK, NO_CONTENT, NOT_FOUND } from 'http-status';
+import {
+  OK,
+  NO_CONTENT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  BAD_REQUEST,
+} from 'http-status';
+
+const setHeader = (token: Secret) => {
+  return {
+    Cookie: `UID=${token}`,
+    Accept: 'application/json',
+  };
+};
 
 beforeAll(async () => {
   sequelize.options.logging = false;
@@ -111,5 +127,46 @@ describe('GET /api/events/coordinate', () => {
       .get('/api/events/coordinate')
       .query({ place: '!@#' })
       .expect(NO_CONTENT);
+  });
+});
+
+describe('GET /api/events/:eventId/users', () => {
+  it('로그인을 안했을 경우 401', async () => {
+    const token = await generateJWT(false, 2, 1, '1234@gmail.com');
+    await request(app)
+      .get('/api/events/2/users')
+      .set(setHeader(token))
+      .expect(UNAUTHORIZED);
+  });
+  it('이벤트가 없는 경우 404', async () => {
+    const token = await generateJWT(true, 2, 1, '1234@gmail.com');
+    await request(app)
+      .get('/api/events/0/users')
+      .set(setHeader(token))
+      .expect(NOT_FOUND);
+  });
+  it('주최한 유저와 이벤트가 다를경우 (다른 유저의 이벤트를 보려고 하는 경우) 400', async () => {
+    const token = await generateJWT(true, 2, 1, '1234@gmail.com');
+    await request(app)
+      .get('/api/events/1/users')
+      .set(setHeader(token))
+      .expect(BAD_REQUEST);
+  });
+  it('내 이벤트에 접근한 경우, 티켓이 없을 때 204', async () => {
+    const token = await generateJWT(true, 2, 1, '1234@gmail.com');
+    await request(app)
+      .get('/api/events/9/users')
+      .set(setHeader(token))
+      .expect(NO_CONTENT);
+  });
+  it('내 이벤트에 접근한 경우 200', async () => {
+    const token = await generateJWT(true, 2, 1, '1234@gmail.com');
+    await request(app)
+      .get('/api/events/2/users')
+      .set(setHeader(token))
+      .expect(OK)
+      .expect(res => {
+        expect(res.body).toMatchSnapshot();
+      });
   });
 });


### PR DESCRIPTION
### 관련 이슈

#313

### 변경 사항 및 이유

관리자 페이지에서 사용할 모든 티켓을 불러오는 API,
GET /api/events/:eventId/users 로 접근이 가능하며 로그인이 되어있어야만 한다.
반환하는 정보는 아래와 같음
```ts
[
  {
    "id": 2,
    "firstName": '성동',
    "lastName": '조',
    "phoneNumber": '01012341234',
    "email": 'sdong001@gmail.com'
    "userTickets":[
      {
        "id": 1,
        "ticketTypeId": 2,
        "userId": 2,
        "isAttendance": true,
        "createdAt": "2019-12-10T04:54:17.000Z"
      },
      ...
    ]
  },
  ...
]
```
나머지 에러 코드에 관련된 사항은 테스트 코드 참고

### PR Point

reducer와 Interface 이름좀 봐주세요.

### 참고 사항

이름 바꾸라 해도 안바꿀꺼에요.

### Check Point

- [x] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
