### PR TITLE
[PR] DB seed를 제외한 테스트 스크립트 작성

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "redis:delete": "ts-node -r tsconfig-paths/register bin/redis-delete",
     "build": "tsc --sourceMap false",
     "test": "jest --coverage --verbose",
+    "test:noseed": "jest --coverage --verbose --testPathIgnorePatterns test/db/seed",
     "format": "prettier --write \"**/*.{spec.ts,ts,tsx,js,jsx,json,scss,css,md}\"",
     "lint": "tsc --noEmit && eslint . --cache --ext .ts,.tsx",
     "lint:fix": "tsc --noEmit && eslint . --cache --fix --ext .ts,.tsx",


### PR DESCRIPTION
### 관련 이슈

#300

### 변경 사항 및 이유

DB seed 미포함 테스트 스크립트를 작성했습니다.

자세한 사항은 이슈를 참고해주세요!

### PR Point

아래의 line 이 추가되었습니다. `testPathIgnorePatterns` 옵션을 추가하여 test/db/seed가 포함되는 파일은 제외됩니다.
```json
"test:noseed": "jest --coverage --verbose --testPathIgnorePatterns test/db/seed"
```

앞으로 서버에서 테스트 진행 시에
- DB seed 포함 `yarn workspace server test`
- DB seed 미포함 `yarn workspace server test:noseed`
를 이용하면 될 것 같습니다.

### 참고 사항

더 개선한다면 transaction으로 롤백하는 방향도 있을 것 같습니다.

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
