### PR TITLE
[PR] 성과 이름의 vaildation 이 다르게 보여지는 문제 해결

### DIFF
--- a/client/cypress/integration/signup.spec.ts
+++ b/client/cypress/integration/signup.spec.ts
@@ -1,5 +1,11 @@
 /// <reference types="Cypress" />
 
+import {
+  SIGNUP_VALIDATION_FIRST_NAME,
+  SIGNUP_VALIDATION_LAST_NAME,
+  SIGNUP_VALIDATION_PHONE_NUMBER,
+} from '../../src/commons/constants/string';
+
 context('회원가입 페이지', () => {
   beforeEach(() => {
     cy.server();
@@ -25,6 +31,7 @@ context('회원가입 페이지', () => {
     cy.get('[data-testid=signupform-lastname]').type('test');
     cy.get('[data-testid=formcaption]').within(items => {
       expect(items[1]).to.have.css('visibility', 'visible');
+      expect(items[1]).to.have.text(SIGNUP_VALIDATION_LAST_NAME);
     });
   });
 
@@ -39,6 +46,7 @@ context('회원가입 페이지', () => {
     cy.get('[data-testid=signupform-firstname]').type('test');
     cy.get('[data-testid=formcaption]').within(items => {
       expect(items[2]).to.have.css('visibility', 'visible');
+      expect(items[2]).to.have.text(SIGNUP_VALIDATION_FIRST_NAME);
     });
   });
 
@@ -53,6 +61,7 @@ context('회원가입 페이지', () => {
     cy.get('[data-testid=signupform-phonenumber]').type('0101234');
     cy.get('[data-testid=formcaption]').within(items => {
       expect(items[3]).to.have.css('visibility', 'visible');
+      expect(items[3]).to.have.text(SIGNUP_VALIDATION_PHONE_NUMBER);
     });
   });
 

--- a/client/src/commons/constants/string.ts
+++ b/client/src/commons/constants/string.ts
@@ -5,14 +5,22 @@ export const LOGIN_SOCIAL = '소셜 계정을 사용해서 로그인';
 export const BEFORE_LOGIN = '가입 혹은 로그인';
 export const FOOTER_INFO =
   '대표 이메일 boostcamp@festa.io\n북어스(BookUs) | 대표 부캠이 | 서울특별시 서울구 서울동 서울로 123-1234 | 통신판매업 12345678 | 대표전화 123-1234-1234 (문의는 이메일 바랍니다)';
+
 export const SIGNUP_EMAIL = '이메일';
 export const SIGNUP_LAST_NAME = '성';
 export const SIGNUP_FIRST_NAME = '이름';
 export const SIGNUP_PHONE_NUMBER = '휴대폰 번호';
 export const SIGNUP_BTN = '회원가입';
+export const SIGNUP_VALIDATION_EMAIL = '이메일을 입력하세요';
+export const SIGNUP_VALIDATION_FIRST_NAME = '이름을 입력하세요';
+export const SIGNUP_VALIDATION_LAST_NAME = '성을 입력하세요';
+export const SIGNUP_VALIDATION_PHONE_NUMBER = '올바른 휴대폰 번호가 아닙니다.';
+export const SIGNUP_PLACEHOLDER_PHONE_NUMBER = '- 없이 숫자만 입력해주세요.';
+
 export const COUNTER_LABEL = '수량';
 export const BUY_TICKET_BTN = '구매하기';
 export const COUNTER_BOX_LABEL = '수량';
+
 export const RESERVE_REQUIRE_CHOICE = '티켓을 선택해주세요.';
 export const RESERVE_REQUIRE_LOGIN = '로그인이 필요합니다.';
 export const RESERVE_COMPLETE = '예약이 완료되었습니다';
@@ -21,6 +29,7 @@ export const RESERVE_MIN_FAIL = '하나 이상의 티켓만 구매할 수 있습
 export const RESERVE_INVALID_DATE = '구매 가능한 일정이 아닙니다.';
 export const RESERVE_SOLD_OUT = '매진되었습니다.';
 export const RESERVE_PER_PERSON_OVER = '1인당 구매 가능한 티켓을 초과했습니다.';
+
 export const JOIN_STEP_CHOICE = '티켓 선택';
 export const JOIN_STEP_PURCHASE = '결제';
 export const TICKET_CHOICE_TITLE = 'Tickets';
@@ -28,7 +37,9 @@ export const TICKET_PURCHASE_TITLE = '결제';
 export const TOTAL_PRICE_LABEL = '총 결제할 금액';
 export const TICKET_PURCHASE_BTN = '티켓 구입';
 export const TICKETBOX_REFUND_BTN = '환불하기';
+
 export const MY_TICKETS_STEP = 'tickets';
 export const CREATED_EVENTS_STEP = 'events';
+
 export const MY_TICKETS_TITLE = '구매 완료한 티켓';
 export const MY_CREATED_EVENTS = '나의 주최한 이벤트';

--- a/client/src/pages/SignUp/view.tsx
+++ b/client/src/pages/SignUp/view.tsx
@@ -12,6 +12,11 @@ import {
   SIGNUP_LAST_NAME,
   SIGNUP_PHONE_NUMBER,
   SIGNUP_BTN,
+  SIGNUP_VALIDATION_EMAIL,
+  SIGNUP_VALIDATION_FIRST_NAME,
+  SIGNUP_VALIDATION_LAST_NAME,
+  SIGNUP_VALIDATION_PHONE_NUMBER,
+  SIGNUP_PLACEHOLDER_PHONE_NUMBER,
 } from 'commons/constants/string';
 
 function SignUpView(): React.ReactElement {
@@ -24,7 +29,7 @@ function SignUpView(): React.ReactElement {
   const FormInputs = {
     email: {
       inputName: 'email',
-      captionContent: '이메일을 입력하세요',
+      captionContent: SIGNUP_VALIDATION_EMAIL,
       disabled: true,
       value: email || '',
       labelProps: {
@@ -34,7 +39,7 @@ function SignUpView(): React.ReactElement {
     },
     firstName: {
       inputName: 'firstName',
-      captionContent: '성을 입력하세요',
+      captionContent: SIGNUP_VALIDATION_FIRST_NAME,
       invalid: firstNameValidate,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
         const { value } = e.target;
@@ -47,7 +52,7 @@ function SignUpView(): React.ReactElement {
     },
     lastName: {
       inputName: 'lastName',
-      captionContent: '이름을 입력하세요',
+      captionContent: SIGNUP_VALIDATION_LAST_NAME,
       invalid: lastNameValidate,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
         const { value } = e.target;
@@ -60,8 +65,8 @@ function SignUpView(): React.ReactElement {
     },
     phoneNumber: {
       inputName: 'phoneNumber',
-      captionContent: '올바른 휴대폰 번호가 아닙니다.',
-      placeholder: '- 없이 숫자만 입력해주세요.',
+      captionContent: SIGNUP_VALIDATION_PHONE_NUMBER,
+      placeholder: SIGNUP_PLACEHOLDER_PHONE_NUMBER,
       invalid: phoneValidate,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
         const { value } = e.target;


### PR DESCRIPTION
### 관련 이슈

#345  #355 

### 변경 사항 및 이유

성과 이름의 유효성 검사 텍스트가 반대로 표시되는 문제 해결
- 매직넘버를 상수 변수 사용으로 수정
- Validation의 텍스트까지 검사하도록 테스트를 수정
```js
expect(items[1]).to.have.text(SIGNUP_VALIDATION_LAST_NAME);
```
### PR Point

.

### 참고 사항

.

### Check Point

- [x] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
