### PR TITLE
[PR] EventDetail(이벤트 상세 페이지) 에서 date format 미설정

### DIFF
--- a/client/src/components/atoms/EventDate/index.tsx
+++ b/client/src/components/atoms/EventDate/index.tsx
@@ -16,12 +16,9 @@ function EventDate({
   children,
 }: EventDateProps): React.ReactElement {
   if (startAt && endAt) {
-    return <S.Wrapper>{calculateStringOfDateRange(startAt, endAt)}</S.Wrapper>;
-  } else if (children) {
-    return <S.Wrapper>{getKoreanDateString(children)}</S.Wrapper>;
-  } else {
-    return <></>;
+    return <>{calculateStringOfDateRange(startAt, endAt)}</>;
   }
+  return <>{children ? getKoreanDateString(children) : ''}</>;
 }
 
 export default EventDate;

--- a/client/src/components/organisms/EventHeader/index.tsx
+++ b/client/src/components/organisms/EventHeader/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import { IconBtn, Price } from 'components';
+import { IconBtn, Price, EventDate } from 'components';
 import { User, TicketType } from 'types/Data';
 import { default as Theme } from 'commons/style/themes/default';
 import { FaUsers, FaExternalLinkAlt } from 'react-icons/fa';
@@ -44,8 +44,9 @@ function EventHeader({
           <S.HostDetailContainer>
             <S.Label>일시</S.Label>
             <S.DateContainer>
-              <S.Date>{startAt}</S.Date>
-              <S.Date>{endAt}</S.Date>
+              <S.Date>
+                <EventDate startAt={startAt} endAt={endAt} />
+              </S.Date>
             </S.DateContainer>
             <S.Label>주최</S.Label>
             <IconBtn

--- a/client/src/components/organisms/EventHeader/style.ts
+++ b/client/src/components/organisms/EventHeader/style.ts
@@ -68,7 +68,8 @@ export const Label = styled.div`
 `;
 
 export const Date = styled.div`
-  ${theme('fontStyle.subtitle2')}
+  ${theme('fontStyle.subtitle1')}
+  white-space: pre;
 `;
 
 export const PriceWrapper = styled.div`


### PR DESCRIPTION
### 관련 이슈

#358 

### 변경 사항 및 이유

이벤트 상세 페이지에서 data format이 변환되지 않은 사항을 정상적으로 보여지도록 수정
<img width="1047" alt="스크린샷 2019-12-14 오후 4 03 38" src="https://user-images.githubusercontent.com/22005861/70844898-4bd8ac80-1e8b-11ea-8796-5b13a562a039.png">


### PR Point

`EventDate` Component를 사용하도록 수정

### 참고 사항

.

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [ ] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
