### PR TITLE
[PR] TicketBox에서 종료일자 계산 개선

### DIFF
--- a/client/src/components/organisms/TicketBox/index.tsx
+++ b/client/src/components/organisms/TicketBox/index.tsx
@@ -32,7 +32,6 @@ function TicketBox({
   price,
   name,
   desc,
-  salesStartAt,
   salesEndAt,
   showChkIcon,
   chkDesc,
@@ -42,7 +41,11 @@ function TicketBox({
   showRefundBtn,
 }: Props): React.ReactElement {
   const [isChecked, setChecked] = useState(checked);
-  const remainDays = calculateDiffDaysOfDateRange(salesStartAt, salesEndAt);
+
+  const remainDays = calculateDiffDaysOfDateRange(
+    Date().toString(),
+    salesEndAt,
+  );
 
   if (chkProps.onClick) {
     const copyParentOnClick = Object.assign(chkProps.onClick);
@@ -79,7 +82,11 @@ function TicketBox({
         {showDueDate && (
           <IconLabel
             icon={<FaTicketAlt size={'1.5rem'} />}
-            labelContent={`${remainDays}일 후에 판매마감`}
+            labelContent={
+              remainDays !== 0
+                ? `${remainDays}일 후에 판매마감`
+                : '오늘 마감입니다!'
+            }
           />
         )}
       </S.TicketInfoContainer>

--- a/client/src/utils/dateCalculator/index.spec.ts
+++ b/client/src/utils/dateCalculator/index.spec.ts
@@ -60,10 +60,16 @@ describe('datecalculateulator', () => {
   });
 
   it('날짜의 차를 계산하여 반환한다', () => {
+    // given
+    const future = '2019-03-09T10:30:00.000Z';
+    const fast = '2018-03-09T12:30:00.000Z';
+
     // when
     const diffDays = calculateDiffDaysOfDateRange(startAt, endAt);
+    const diffDaysOfStartAndFast = calculateDiffDaysOfDateRange(future, fast);
 
     // then
     expect(diffDays).toBe(1);
+    expect(diffDaysOfStartAndFast).toBe(-365);
   });
 });


### PR DESCRIPTION
### 관련 이슈

#359

### 변경 사항 및 이유

- 판매 시작 날짜를 기준에서 오늘 날짜 기준으로 수정, 이 때 필요하지 않게된 `salesStartAt`도 제거
- 당일에(0일 후 마감일 시) 마감일 경우 `오늘 마감입니다!`를 보여주도록 수정
- 현재 또는 미래에서 -> 과거로 날짜 차이 값을 계산할 때 음수가 나오는지 테스트를 추가함

### PR Point

.

### 참고 사항

- 버그 이슈로써 있는 종료일자 오류는 실제 DB에 저장된 값이 2200년으로 설정되어 있었던 것이라 DB를 수정해야함

### Check Point

- [x] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
