### PR TITLE
[PR] currencyDecorator 일반화 및 InputOnlyNumber 컴포넌트 구현

### DIFF
--- a/client/src/components/atoms/InputOnlyNumber/index.stories.tsx
+++ b/client/src/components/atoms/InputOnlyNumber/index.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import InputOnlyNumber from '.';
+
+export default {
+  title: 'Atoms / InputOnlyNumber',
+};
+
+export const index: React.FC = () => {
+  return <InputOnlyNumber inputName={'email'} />;
+};

--- a/client/src/components/atoms/InputOnlyNumber/index.tsx
+++ b/client/src/components/atoms/InputOnlyNumber/index.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import Input, { Props as InputProps } from 'components/atoms/Input';
+import numberDecorator from 'utils/numberDecorator';
+
+export const handleNumber = (value: string) => {
+  const re = /^([0-9]*[0-9|\,]*[0-9]+){0,7}$/;
+  if (value.length < 10 && (value === '' || re.test(value)))
+    return numberDecorator({
+      mount: +value.replace(/\,/g, ''),
+      separated: true,
+    });
+};
+
+function InputOnlyNumber({
+  inputName,
+  onChange,
+  ...props
+}: InputProps): React.ReactElement {
+  const [number, setNumber] = useState<string>('');
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formattedNumber = handleNumber(e.target.value);
+    if (formattedNumber) setNumber(formattedNumber);
+  };
+
+  return (
+    <Input
+      inputName={inputName}
+      value={number}
+      onChange={handleOnChange}
+      {...props}
+    />
+  );
+}
+
+export default InputOnlyNumber;

--- a/client/src/components/atoms/InputOnlyNumber/index.tsx
+++ b/client/src/components/atoms/InputOnlyNumber/index.tsx
@@ -3,10 +3,11 @@ import Input, { Props as InputProps } from 'components/atoms/Input';
 import numberDecorator from 'utils/numberDecorator';
 
 export const handleNumber = (value: string) => {
-  const re = /^([0-9]*[0-9|\,]*[0-9]+){0,7}$/;
-  if (value.length < 10 && (value === '' || re.test(value)))
+  const onlyString = value.replace(/\,/g, '');
+  const re = /^[0-9]{0,7}$/;
+  if (value === '' || re.test(onlyString))
     return numberDecorator({
-      mount: +value.replace(/\,/g, ''),
+      mount: +onlyString,
       separated: true,
     });
 };

--- a/client/src/components/atoms/Price/index.tsx
+++ b/client/src/components/atoms/Price/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as S from './style';
-import currencyDecorator from 'utils/currencyDecorator';
+import numberDecorator from 'utils/numberDecorator';
 
 export interface PriceProps {
   children: number;
@@ -14,7 +14,11 @@ function Price({
   currency = '₩',
   separated = false,
 }: PriceProps): React.ReactElement {
-  const convertedCurrency = currencyDecorator(children, currency, separated);
+  const convertedCurrency = numberDecorator({
+    mount: children,
+    currency,
+    separated,
+  });
 
   return (
     <S.Wrapper>

--- a/client/src/utils/numberDecorator/index.spec.ts
+++ b/client/src/utils/numberDecorator/index.spec.ts
@@ -1,13 +1,13 @@
-import currencyDecorator from '.';
+import numberDecorator from '.';
 
-describe('currencyDecorator', () => {
+describe('numberDecorator', () => {
   // given
   const mount = 16000000;
   const currency = '₩';
   const separated = true;
 
   // when
-  const result = currencyDecorator(mount, currency, separated);
+  const result = numberDecorator({ mount, currency, separated });
 
   it('currency가 표시된다.', () => {
     const currencyIndex = result.indexOf('₩');
@@ -30,7 +30,7 @@ describe('currencyDecorator', () => {
 
   it('separted에 따라 분리하지 않는다', () => {
     // given
-    const nonSeparated = currencyDecorator(mount, currency, false);
+    const nonSeparated = numberDecorator({ mount, currency, separated: false });
 
     // when (non-separated)
     const commas = nonSeparated.split(',');

--- a/client/src/utils/numberDecorator/index.ts
+++ b/client/src/utils/numberDecorator/index.ts
@@ -1,4 +1,9 @@
-export default (mount: number, currency: '₩' | '$', separated: boolean) => {
+interface Props {
+  mount: number;
+  currency?: '₩' | '$';
+  separated: boolean;
+}
+export default ({ mount, currency, separated }: Props) => {
   const seperator = (targetStr: string) => {
     return targetStr
       .split('')
@@ -16,9 +21,8 @@ export default (mount: number, currency: '₩' | '$', separated: boolean) => {
   };
 
   let mountStr = `${mount}`;
-  if (separated) {
-    mountStr = seperator(mountStr);
-  }
+  if (separated) mountStr = seperator(mountStr);
 
-  return `${currency} ${mountStr}`;
+  if (currency) return `${currency} ${mountStr}`;
+  return mountStr;
 };


### PR DESCRIPTION
### 관련 이슈

#407 currencyDecorator 일반화
및
InputOnlyNumber 컴포넌트 구현

### 변경 사항 및 이유

오롯이 숫자만 입력가능한 컴포넌트가 필요하여, currencyDecorator을 개선하여 구현했습니다.
![image](https://user-images.githubusercontent.com/28642472/70957309-0d283980-20b9-11ea-9fc2-18a2b31d2138.png)


### PR Point

<!— 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 —>

### 참고 사항

<!— 참고할 사항이 있다면 적어주세요. —>

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [ ] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [ ] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
