### PR TITLE
[PR] 무료 이벤트에 대해 표시되는 텍스트 수정

### DIFF
--- a/client/src/components/atoms/Price/index.tsx
+++ b/client/src/components/atoms/Price/index.tsx
@@ -14,15 +14,15 @@ function Price({
   currency = '₩',
   separated = false,
 }: PriceProps): React.ReactElement {
-  const convertedCurrency = numberDecorator({
-    mount: children,
-    currency,
-    separated,
-  });
-
   return (
     <S.Wrapper>
-      {+convertedCurrency === 0 ? '무료' : convertedCurrency}
+      {+children === 0
+        ? '무료'
+        : numberDecorator({
+            mount: children,
+            currency,
+            separated,
+          })}
     </S.Wrapper>
   );
 }


### PR DESCRIPTION
### 관련 이슈

#413

### 변경 사항 및 이유

```js
    <S.Wrapper>
      {+children === 0
        ? '무료'
        : numberDecorator({
            mount: children,
            currency,
            separated,
          })}
    </S.Wrapper>
```

### PR Point
<img width="256" alt="스크린샷 2019-12-17 오후 1 23 31" src="https://user-images.githubusercontent.com/22005861/70964766-6fd8ff80-20d0-11ea-999a-ce1e7eabd224.png">

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️

