### PR TITLE
[PR] 이벤트 만들기 API 검증 로직 수정

### DIFF
--- a/client/cypress/integration/eventjoin.spec.ts
+++ b/client/cypress/integration/eventjoin.spec.ts
@@ -25,6 +25,7 @@ context('이벤트 예약 페이지', () => {
   beforeEach(() => {
     cy.server();
     cy.setCookie('UID', Cypress.env('auth_token'));
+    cy.wait(2000);
   });
 
   it('티켓을 선택하지 않고 구매를 시도한다면 alert가 표시된다.', () => {

--- a/server/src/routes/api/events/validators/createEvent.ts
+++ b/server/src/routes/api/events/validators/createEvent.ts
@@ -9,6 +9,18 @@ const isGreaterThan = (key: string): { options: CustomValidator } => ({
   options: (value, { req }) => resolveObject(req.body, key) <= value,
 });
 
+const isBetween = (
+  startKey: string,
+  endKey: string,
+): { options: CustomValidator } => ({
+  options: (value, { req }): boolean => {
+    const start = resolveObject(req.body, startKey);
+    const end = resolveObject(req.body, endKey);
+
+    return value >= start && value <= end;
+  },
+});
+
 export default checkSchema({
   isPublic: {
     in: 'body',
@@ -20,7 +32,7 @@ export default checkSchema({
     in: 'body',
     isString: true,
     exists: true,
-    isLength: { options: { min: 5, max: 255 } },
+    isLength: { options: { min: 1, max: 255 } },
   },
   startAt: {
     in: 'body',
@@ -40,16 +52,19 @@ export default checkSchema({
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 255 } },
   },
   address: {
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 255 } },
   },
   placeDesc: {
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 255 } },
   },
   latitude: {
     in: 'body',
@@ -65,16 +80,19 @@ export default checkSchema({
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 65535 } },
   },
   'ticket.name': {
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 255 } },
   },
   'ticket.desc': {
     in: 'body',
     isString: true,
     exists: true,
+    isLength: { options: { min: 1, max: 255 } },
   },
   'ticket.price': {
     in: 'body',
@@ -106,20 +124,20 @@ export default checkSchema({
     isISO8601: true,
     exists: true,
     toDate: true,
-    isAfter: { options: new Date().toString() },
+    custom: isBetween('startAt', 'endAt'),
   },
   'ticket.salesEndAt': {
     in: 'body',
     isISO8601: true,
     exists: true,
     toDate: true,
-    custom: isGreaterThan('ticket.salesStartAt'),
+    custom: isBetween('ticket.salesStartAt', 'endAt'),
   },
   'ticket.refundEndAt': {
     in: 'body',
     isISO8601: true,
     exists: true,
     toDate: true,
-    custom: isGreaterThan('ticket.salesEndAt'),
+    custom: isBetween('ticket.salesStartAt', 'endAt'),
   },
 });

--- a/server/test/api/event.spec.ts
+++ b/server/test/api/event.spec.ts
@@ -109,8 +109,8 @@ describe('POST /api/events', () => {
   const defaultData: Record<string, string | boolean | number> = {
     isPublic: true,
     title: '이벤트의 제목',
-    startAt: '2200-12-15 10:00:00',
-    endAt: '2201-05-01 13:00:00',
+    startAt: '2200-01-01 10:00:00',
+    endAt: '2300-12-30 13:00:00',
     place: '패스트파이브 강남 4호점',
     address: '서울시 강남구',
     placeDesc: '주차 불가',
@@ -123,9 +123,9 @@ describe('POST /api/events', () => {
     'ticket[isPublicLeftCnt]': false,
     'ticket[maxCntPerPerson]': 10,
     'ticket[price]': 10000,
-    'ticket[salesStartAt]': '2200-12-15 10:00:00',
-    'ticket[salesEndAt]': '2200-12-17 13:00:00',
-    'ticket[refundEndAt]': '2200-12-20 13:00:00',
+    'ticket[salesStartAt]': '2220-12-15 10:00:00',
+    'ticket[salesEndAt]': '2250-12-17 13:00:00',
+    'ticket[refundEndAt]': '2240-12-20 13:00:00',
   };
 
   function getRequest(
@@ -156,12 +156,23 @@ describe('POST /api/events', () => {
     await getRequest({}, undefined, false).expect(UNAUTHORIZED);
   });
 
+  it('제목이 256 자 이상이면 400 응답', async () => {
+    const titleCount = 256;
+    await getRequest({
+      title: '0'.repeat(titleCount),
+    }).expect(BAD_REQUEST);
+  });
+
   it('startAt 이 오늘보다 전이면 400 응답', async () => {
-    await getRequest({ startAt: '1900-03-01 13:00:00' }).expect(BAD_REQUEST);
+    await getRequest({
+      startAt: '1900-03-01 13:00:00',
+    }).expect(BAD_REQUEST);
   });
 
   it('startAt 이 endAt 보다 크면 400 응답', async () => {
-    await getRequest({ startAt: '2202-03-01 13:00:00' }).expect(BAD_REQUEST);
+    await getRequest({
+      startAt: '2402-03-01 13:00:00',
+    }).expect(BAD_REQUEST);
   });
 
   it('ticket 의 maxCntPerPerson 가 quantity 보다 크면 400 응답', async () => {
@@ -169,13 +180,19 @@ describe('POST /api/events', () => {
   });
 
   it('ticket 의 salesStartAt 가 salesEndAt 보다 늦으면 400 응답', async () => {
-    await getRequest({ 'ticket[salesEndAt]': '2201-03-01 13:00:00' }).expect(
+    await getRequest({ 'ticket[salesStartAt]': '2261-03-01 13:00:00' }).expect(
       BAD_REQUEST,
     );
   });
 
-  it('ticket 의 refundEndAt 이 refundEndAt 보다 늦으면 400 응답', async () => {
-    await getRequest({ 'ticket[salesStartAt]': '2202-03-01 13:00:00' }).expect(
+  it('ticket 의 refundEndAt 이 endAt 보다 늦으면 400 응답', async () => {
+    await getRequest({ 'ticket[refundEndAt]': '2502-03-01 13:00:00' }).expect(
+      BAD_REQUEST,
+    );
+  });
+
+  it('ticket 의 refundEndAt 이 startAt 보다 빠르면 400 응답', async () => {
+    await getRequest({ 'ticket[refundEndAt]': '2002-03-01 13:00:00' }).expect(
       BAD_REQUEST,
     );
   });


### PR DESCRIPTION
### 관련 이슈
#427 

### 변경 사항 및 이유
- salesStartAt 이 event 의 startAt 과 endAt 사이에 있어야 함
- salesEndAt 은 salesStartAt 과 endAt 사이에 있어야 함
- refundEndAt 은 salesStartAt 과 endAt 사이에 있어야 함
- database datatype varchar length 에 따른 검증 추가

### PR Point
- 위 검증 논리가 맞는지 봐주세요

### 참고 사항


### Check Point

- [x] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
