### PR TITLE
[PR] 이벤트 티켓 구매 페이지에서 이미지 안나오는 문제 해결

### DIFF
--- a/client/src/pages/EventJoin/index.tsx
+++ b/client/src/pages/EventJoin/index.tsx
@@ -40,6 +40,7 @@ import { NOT_OPEN, SOLD_OUT, EXCEED_LIMIT } from 'commons/constants/number';
 import ROUTES from 'commons/constants/routes';
 import { joinEvent } from 'apis';
 import { calculateStringOfDateRange } from 'utils/dateCalculator';
+import { getImageURL, imageTypes } from 'utils/getImageURL';
 
 const minTicketCount = 1;
 const steps = [JOIN_STEP_CHOICE, JOIN_STEP_PURCHASE];
@@ -178,7 +179,7 @@ function EventJoin(): React.ReactElement {
             calculateStringOfDateRange(startAt, endAt),
             user.lastName + user.firstName,
           ]}
-          imgSrc={mainImg}
+          imgSrc={getImageURL(mainImg, imageTypes.eventDetailRegisterImg)}
         />
       }
       place={<Place mapHeight={'20rem'} {...eventState} />}

--- a/client/src/utils/getImageURL/imageTypes.ts
+++ b/client/src/utils/getImageURL/imageTypes.ts
@@ -1,6 +1,7 @@
 enum imageTypeEnum {
   mainEventImg,
   eventDetailImg,
+  eventDetailRegisterImg,
 }
 
 export interface ImageType {
@@ -20,4 +21,5 @@ export const imageTypes: Record<keyof typeof imageTypeEnum, ImageType> = {
     height: 387,
     type: 'f',
   },
+  eventDetailRegisterImg: { width: 688, height: 387, type: 'f' },
 };

--- a/client/src/utils/getImageURL/imageTypes.ts
+++ b/client/src/utils/getImageURL/imageTypes.ts
@@ -16,8 +16,8 @@ export const imageTypes: Record<keyof typeof imageTypeEnum, ImageType> = {
     type: 'f',
   },
   eventDetailImg: {
-    width: 240,
-    height: 135,
+    width: 688,
+    height: 387,
     type: 'f',
   },
 };


### PR DESCRIPTION
### 관련 이슈
#428 

### 변경 사항 및 이유
이벤트 티켓 구매 페이지에서 이미지 안나오는 문제 해결

### PR Point
- imageType 이 detail 페이지에서 이미지가 캐시될 것이라고 기대하고, 그대로 사용하였습니다.

### 참고 사항


### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [ ] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [ ] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
