### PR TITLE
[PR] 이벤트 상세, 예약페이지 개선

### DIFF
--- a/client/cypress/integration/eventjoin.spec.ts
+++ b/client/cypress/integration/eventjoin.spec.ts
@@ -186,6 +186,6 @@ context('이벤트 예약 페이지', () => {
         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_COMPLETE);
       });
 
-    cy.location('pathname').should('eq', '/');
+    cy.location('pathname').should('eq', '/my/tickets');
   });
 });

--- a/client/src/commons/constants/string.ts
+++ b/client/src/commons/constants/string.ts
@@ -138,6 +138,10 @@ export const REFUND_TICKET_FAILURE = '환불이 실패했습니다.';
 export const NOT_FOUND_BOUGHT_TICKET = '아직 구매한 티켓이 없네요..😅';
 export const NOT_FOUND_CREATED_EVENT = '주최한 이벤트가 없네요..🤣';
 
+export const TICKET_REMAIN_DAYS = '일 후에 판매마감';
+export const TICKET_INVALID_DATE = '판매기간이 지났습니다';
+export const TICKET_COMMING_SOON = '일 후 판매시작';
+
 export const FORM_NAME: any = {
   event: {
     isPublic: '공개 여부',

--- a/client/src/commons/constants/string.ts
+++ b/client/src/commons/constants/string.ts
@@ -5,6 +5,8 @@ export const LOGIN_SOCIAL = '소셜 계정을 사용해서 로그인';
 export const BEFORE_LOGIN = '가입 혹은 로그인';
 export const FOOTER_INFO =
   '대표 이메일 boostcamp@festa.io\n북어스(BookUs) | 대표 부캠이 | 서울특별시 서울구 서울동 서울로 123-1234 | 통신판매업 12345678 | 대표전화 123-1234-1234 (문의는 이메일 바랍니다)';
+export const INTERNAL_SERVER_ERROR =
+  '서버 요청에 실패했습니다. 잠시 후에 다시 시도해주세요';
 
 export const SIGNUP_EMAIL = '이메일';
 export const SIGNUP_LAST_NAME = '성';
@@ -131,7 +133,6 @@ export const BOUGHT_TICKET_EVENT_TITLE_CAPTION = '현재 구매한 티켓 목록
 export const HISTORY_METHOD_PUSH = 'PUSH';
 export const HISTORY_METHOD_REPLACE = 'REPLACE';
 
-
 export const REFUND_TICKET_SUCCESS = '환불이 완료되었습니다.';
 export const REFUND_TICKET_FAILURE = '환불이 실패했습니다.';
 export const NOT_FOUND_BOUGHT_TICKET = '아직 구매한 티켓이 없네요..😅';
@@ -164,4 +165,3 @@ export const FORM_NAME: any = {
     refundEndAt: '티켓 환불 마감 날짜',
   },
 };
-

--- a/client/src/components/organisms/EventHeader/index.tsx
+++ b/client/src/components/organisms/EventHeader/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   endAt: string;
   user: User;
   ticketType: TicketType;
-  doneEvent?: boolean;
+  doneEventType?: number;
 }
 
 function EventHeader({
@@ -26,12 +26,13 @@ function EventHeader({
   endAt,
   user,
   ticketType,
-  doneEvent,
+  doneEventType,
 }: Props): React.ReactElement {
   const ticketInfo = ticketType;
   const { firstName, lastName } = user;
   const profileImgUrl =
     'https://kr.object.ncloudstorage.com/bookus/defaultProfileImg.png';
+  const doneTypes = ['등록', '종료되었습니다.', '매진되었습니다.'];
 
   return (
     <S.HeaderContainer>
@@ -71,9 +72,9 @@ function EventHeader({
           <S.ReservedPeople>{ticketInfo.leftCnt}명</S.ReservedPeople>
         </S.ReservedPeopleContainer>
         <S.SubmitBtn
-          children={doneEvent ? '이벤트 종료' : '등록'}
+          children={!doneEventType ? doneTypes[0] : doneTypes[doneEventType]}
           to={`/events/${eventId}/register/tickets`}
-          disabled={doneEvent}
+          disabled={doneEventType === 1 || doneEventType === 2}
         />
       </S.SubmitContainer>
     </S.HeaderContainer>

--- a/client/src/components/organisms/Ticket/index.tsx
+++ b/client/src/components/organisms/Ticket/index.tsx
@@ -29,6 +29,7 @@ function Ticket({
     Date().toString(),
     salesEndAt,
   );
+
   return (
     <>
       <S.TicketLabel>티켓</S.TicketLabel>
@@ -50,7 +51,7 @@ function Ticket({
           <IconLabel
             icon={<FaRegCalendarAlt size={'1.5rem'} />}
             labelContent={
-              remainDays <= 0
+              doneEvent
                 ? '판매기간이 종료되었습니다.'
                 : `${remainDays}일 후에 판매마감`
             }

--- a/client/src/components/organisms/Ticket/index.tsx
+++ b/client/src/components/organisms/Ticket/index.tsx
@@ -6,6 +6,11 @@ import { IconLabel, Price } from 'components';
 import { calculateDiffDaysOfDateRange } from 'utils/dateCalculator';
 
 import { FaTicketAlt, FaCheck, FaRegCalendarAlt } from 'react-icons/fa';
+import {
+  TICKET_INVALID_DATE,
+  TICKET_REMAIN_DAYS,
+  TICKET_COMMING_SOON,
+} from 'commons/constants/string';
 
 interface Prop extends TicketType {
   count?: number;
@@ -30,6 +35,25 @@ function Ticket({
     salesEndAt,
   );
 
+  function makeLabelContent(remainDays: number, salesStartAt: string) {
+    if (!doneEvent) {
+      return `${remainDays}${TICKET_REMAIN_DAYS}`;
+    }
+
+    if (remainDays <= 0) {
+      return TICKET_INVALID_DATE;
+    }
+
+    const convertToUTCDate = new Date();
+    convertToUTCDate.setHours(-9);
+
+    const commingDays = calculateDiffDaysOfDateRange(
+      convertToUTCDate.toString(),
+      salesStartAt,
+    );
+    return `${commingDays}${TICKET_COMMING_SOON}`;
+  }
+
   return (
     <>
       <S.TicketLabel>티켓</S.TicketLabel>
@@ -40,21 +64,20 @@ function Ticket({
           </S.TicketPriceWrapper>
           <S.TicketName>{`${name} ${count ? `* ${count}` : ''}`}</S.TicketName>
           <S.TicketDesc>{desc}</S.TicketDesc>
-          <IconLabel
-            icon={<FaTicketAlt size={'1.5rem'} />}
-            labelContent={`${remainCnt}개 남음`}
-          />
+          {leftCnt !== -1 && (
+            <IconLabel
+              icon={<FaTicketAlt size={'1.5rem'} />}
+              labelContent={`${remainCnt}개 남음`}
+            />
+          )}
+
           <IconLabel
             icon={<FaCheck size={'1.5rem'} />}
             labelContent={`1인당 ${maxCntPerPerson}개 구입 가능`}
           />
           <IconLabel
             icon={<FaRegCalendarAlt size={'1.5rem'} />}
-            labelContent={
-              doneEvent
-                ? '판매기간이 종료되었습니다.'
-                : `${remainDays}일 후에 판매마감`
-            }
+            labelContent={makeLabelContent(remainDays, salesStartAt)}
           />
         </S.TicketContentWrapContainer>
       </S.TicketContentContainer>

--- a/client/src/components/organisms/Ticket/style.ts
+++ b/client/src/components/organisms/Ticket/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { theme, palette } from 'styled-tools';
+import { theme, palette, ifProp } from 'styled-tools';
 
 export const TicketLabel = styled.div`
   ${theme('fontStyle.h6')};
@@ -22,7 +22,11 @@ interface TicketContentWrapContainerProps {
 export const TicketContentWrapContainer = styled.div<
   TicketContentWrapContainerProps
 >`
-  color: ${palette('grayscale', 4)}
+  color: ${ifProp(
+    'disabled',
+    palette('grayscale', 4),
+    palette('grayscale', 1),
+  )};
   padding-left: 2rem;
   padding-top: 1rem;
   padding-bottom: 1rem;

--- a/client/src/pages/EventDetail/index.tsx
+++ b/client/src/pages/EventDetail/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useRef } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { NOT_FOUND, INTERNAL_SERVER_ERROR } from 'http-status';
 
@@ -52,6 +52,7 @@ function EventDetailView(): React.ReactElement {
   const [internalServerError, setInternalError] = useState(false);
   const history = useHistory();
   const isEventInState = checkIfEventIsInState(eventsState.events!, +eventId!);
+  const remainDays = useRef(0);
 
   const events = isEventInState
     ? eventsState.events!.get(+eventId!)!
@@ -73,19 +74,24 @@ function EventDetailView(): React.ReactElement {
     longitude,
   } = events;
 
-  const remainDays = calculateDiffDaysOfDateRange(
+  remainDays.current = calculateDiffDaysOfDateRange(
     Date().toString(),
     ticketType.salesEndAt,
   );
 
   useEffect(() => {
-    if (!isEventInState)
+    if (!isEventInState) {
       eventFetchDispatcher({
         type: 'EVENT',
         params: {
           eventId: +eventId!,
         },
       });
+      remainDays.current = calculateDiffDaysOfDateRange(
+        Date().toString(),
+        ticketType.salesEndAt,
+      );
+    }
 
     if (eventsState.status === NOT_FOUND) {
       history.replace('/NOT_FOUND');
@@ -101,6 +107,7 @@ function EventDetailView(): React.ReactElement {
     eventsState.status,
     history,
     isEventInState,
+    ticketType.salesEndAt,
   ]);
 
   return (
@@ -117,11 +124,11 @@ function EventDetailView(): React.ReactElement {
             place,
             ticketType,
           }}
-          doneEvent={remainDays <= 0}
+          doneEvent={remainDays.current <= 0}
         />
       }
       eventContent={<TuiViewer content={desc} />}
-      ticket={<Ticket {...ticketType} doneEvent={remainDays <= 0} />}
+      ticket={<Ticket {...ticketType} doneEvent={remainDays.current <= 0} />}
       place={
         <Place
           {...{

--- a/client/src/pages/EventDetail/index.tsx
+++ b/client/src/pages/EventDetail/index.tsx
@@ -74,10 +74,19 @@ function EventDetailView(): React.ReactElement {
     longitude,
   } = events;
 
-  remainDays.current = calculateDiffDaysOfDateRange(
-    Date().toString(),
-    ticketType.salesEndAt,
-  );
+  function doneEventType() {
+    remainDays.current = calculateDiffDaysOfDateRange(
+      Date().toString(),
+      ticketType.salesEndAt,
+    );
+
+    if (remainDays.current <= 0) return 1;
+
+    const remainTickets = ticketType.quantity - ticketType.leftCnt;
+    if (remainTickets <= 0) return 2;
+
+    return 0;
+  }
 
   useEffect(() => {
     if (!isEventInState) {
@@ -124,11 +133,11 @@ function EventDetailView(): React.ReactElement {
             place,
             ticketType,
           }}
-          doneEvent={remainDays.current <= 0}
+          doneEventType={doneEventType()}
         />
       }
       eventContent={<TuiViewer content={desc} />}
-      ticket={<Ticket {...ticketType} doneEvent={remainDays.current <= 0} />}
+      ticket={<Ticket {...ticketType} doneEvent={!!doneEventType()} />}
       place={
         <Place
           {...{

--- a/client/src/pages/EventJoin/index.tsx
+++ b/client/src/pages/EventJoin/index.tsx
@@ -104,13 +104,14 @@ function EventJoin(): React.ReactElement {
   useEffect(() => {
     if (!eventsState || !eventsState.events) return;
     const gettedEventData = eventsState.events.get(eventId);
-    if (!gettedEventData) return;
-
+    if (!gettedEventData) {
+      eventFetchDispatcher({
+        type: 'EVENT',
+        params: { eventId },
+      });
+      return;
+    }
     getInEventState(gettedEventData);
-    eventFetchDispatcher({
-      type: 'EVENT',
-      params: { eventId },
-    });
   }, [eventFetchDispatcher, eventId, eventsState, getInEventState]);
 
   useEffect(() => {

--- a/client/src/pages/EventJoin/template/index.tsx
+++ b/client/src/pages/EventJoin/template/index.tsx
@@ -12,6 +12,7 @@ interface Props {
   place: React.ReactNode;
   ticketChoiceProps: TicketChoiceProps;
   ticketPurchaseProps: TicketPurchaseProps;
+  loading: boolean;
 }
 
 const TICKET_CHOICE_STEP = 1;
@@ -24,9 +25,10 @@ function EventJoinTemplate({
   place,
   ticketChoiceProps,
   ticketPurchaseProps,
+  loading,
 }: Props): React.ReactElement {
   return (
-    <BasedTemplate hasHeaderLine>
+    <BasedTemplate hasHeaderLine loading={loading}>
       <S.StepListWrapper>{stepList}</S.StepListWrapper>
       <S.Container>
         <S.ContentContainer>
@@ -37,7 +39,7 @@ function EventJoinTemplate({
             <TicketPurchase {...ticketPurchaseProps} />
           )}
           <S.EventContainer>
-            {eventSection}
+            <S.EventSectionWrapper>{eventSection}</S.EventSectionWrapper>
             <S.PlaceWrapper>{place}</S.PlaceWrapper>
           </S.EventContainer>
         </S.ContentContainer>

--- a/client/src/pages/EventJoin/template/style.ts
+++ b/client/src/pages/EventJoin/template/style.ts
@@ -25,6 +25,12 @@ export const EventContainer = styled.div`
   margin-left: 10rem;
 `;
 
+export const EventSectionWrapper = styled.div`
+  & > div {
+    padding: 0rem;
+  }
+`;
+
 export const PlaceWrapper = styled.div`
   margin-top: 3rem;
 `;


### PR DESCRIPTION
### 관련 이슈

#453 #449 

### 변경 사항 및 이유

- [x] 이벤트 상세 페이지에서 예약기간이 남았어도 티켓이 disabled 되지 않던 현상
- [x] 예약 완료 시 내 티켓으로 이동
- [x] 티켓이 열리지 않았을 때 `2일 후 판매시작`과 같은 텍스트가 표시되게
- [x] 티켓 수량 표시가 비공개일 경우 보여주지 않도록 수정
- [x] 티켓 구매페이지에서 이벤트 내용과 지도의 width 일치하게 수정

### PR Point

<!— 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 —>

### 참고 사항

<!— 참고할 사항이 있다면 적어주세요. —>

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [ ] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [ ] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
