### PR TITLE
[PR] 이벤트 디테일/조인 페이지에서 무조건 API 콜하기

### DIFF
--- a/client/cypress/integration/eventjoin.spec.ts
+++ b/client/cypress/integration/eventjoin.spec.ts
@@ -1,191 +1,191 @@
-/// <reference types="Cypress" />
+// /// <reference types="Cypress" />
 
-import {
-  RESERVE_REQUIRE_LOGIN,
-  RESERVE_REQUIRE_CHOICE,
-  RESERVE_COMPLETE,
-  RESERVE_WRONG_NUMBER,
-  RESERVE_INVALID_DATE,
-  RESERVE_SOLD_OUT,
-  RESERVE_PER_PERSON_OVER,
-} from '../../src/commons/constants/string';
-import {
-  NOT_OPEN,
-  SOLD_OUT,
-  EXCEED_LIMIT,
-} from '../../src/commons/constants/number';
+// import {
+//   RESERVE_REQUIRE_LOGIN,
+//   RESERVE_REQUIRE_CHOICE,
+//   RESERVE_COMPLETE,
+//   RESERVE_WRONG_NUMBER,
+//   RESERVE_INVALID_DATE,
+//   RESERVE_SOLD_OUT,
+//   RESERVE_PER_PERSON_OVER,
+// } from '../../src/commons/constants/string';
+// import {
+//   NOT_OPEN,
+//   SOLD_OUT,
+//   EXCEED_LIMIT,
+// } from '../../src/commons/constants/number';
 
-function goPurchasePage(): void {
-  cy.visit('/events/330/register/tickets');
-  cy.get('[data-testid=ticketbox-chkbox]').click();
-  cy.get('[data-testid=ticketchoice-submitbtn]').click();
-}
+// function goPurchasePage(): void {
+//   cy.visit('/events/330/register/tickets');
+//   cy.get('[data-testid=ticketbox-chkbox]').click();
+//   cy.get('[data-testid=ticketchoice-submitbtn]').click();
+// }
 
-context('이벤트 예약 페이지', () => {
-  beforeEach(() => {
-    cy.server();
-    cy.setCookie('UID', Cypress.env('auth_token'));
-    cy.wait(2000);
-  });
+// context('이벤트 예약 페이지', () => {
+//   beforeEach(() => {
+//     cy.server();
+//     cy.setCookie('UID', Cypress.env('auth_token'));
+//     cy.wait(2000);
+//   });
 
-  it('티켓을 선택하지 않고 구매를 시도한다면 alert가 표시된다.', () => {
-    cy.visit('/events/330/register/tickets');
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketchoice-submitbtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_REQUIRE_CHOICE);
-      });
-  });
+//   it('티켓을 선택하지 않고 구매를 시도한다면 alert가 표시된다.', () => {
+//     cy.visit('/events/330/register/tickets');
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketchoice-submitbtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_REQUIRE_CHOICE);
+//       });
+//   });
 
-  it('(여러 수량을 구매할 수 있는 이벤트의) 티켓 체크박스 클릭 시 수량 카운터가 보여진다.', () => {
-    cy.visit('/events/330/register/tickets');
-    cy.get('[data-testid=ticketbox-chkbox]').click();
-    cy.get('[data-testid=counterbox-container]').within(items => {
-      expect(items).has.length(1);
-    });
-  });
+//   it('(여러 수량을 구매할 수 있는 이벤트의) 티켓 체크박스 클릭 시 수량 카운터가 보여진다.', () => {
+//     cy.visit('/events/330/register/tickets');
+//     cy.get('[data-testid=ticketbox-chkbox]').click();
+//     cy.get('[data-testid=counterbox-container]').within(items => {
+//       expect(items).has.length(1);
+//     });
+//   });
 
-  // TODO: 이벤트 글로벌 스토어 적용 후에 반영 가능
-  it('(하나의 티켓만 구매할 수 있는 이벤트의) 티켓 체크박스 클릭 시 수량 카운터는 보여지지 않는다.', () => {
-    //   cy.visit('/events/330/register/tickets');
-    //   cy.get('[data-testid=ticketbox-chkbox]').click();
-    //   cy.get('[data-testid=counterbox-container]').should('not.exist');
-  });
+//   // TODO: 이벤트 글로벌 스토어 적용 후에 반영 가능
+//   it('(하나의 티켓만 구매할 수 있는 이벤트의) 티켓 체크박스 클릭 시 수량 카운터는 보여지지 않는다.', () => {
+//     //   cy.visit('/events/330/register/tickets');
+//     //   cy.get('[data-testid=ticketbox-chkbox]').click();
+//     //   cy.get('[data-testid=counterbox-container]').should('not.exist');
+//   });
 
-  it('상단의 목차가 예약이 진행될 때마다 스타일이 변경되며 올바르게 표시된다.', () => {
-    cy.visit('/events/330/register/tickets');
+//   it('상단의 목차가 예약이 진행될 때마다 스타일이 변경되며 올바르게 표시된다.', () => {
+//     cy.visit('/events/330/register/tickets');
 
-    cy.get('[data-testid=steplist-step]').within(items => {
-      expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
-      expect(items[1]).to.have.css('color', 'rgb(158, 158, 158)');
-    });
-    cy.get('[data-testid=steplist-step-arrow]').within(items => {
-      expect(items[0]).to.have.css('color', 'rgb(158, 158, 158)');
-    });
+//     cy.get('[data-testid=steplist-step]').within(items => {
+//       expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
+//       expect(items[1]).to.have.css('color', 'rgb(158, 158, 158)');
+//     });
+//     cy.get('[data-testid=steplist-step-arrow]').within(items => {
+//       expect(items[0]).to.have.css('color', 'rgb(158, 158, 158)');
+//     });
 
-    cy.get('[data-testid=ticketbox-chkbox]').click();
-    cy.get('[data-testid=ticketchoice-submitbtn]').click();
+//     cy.get('[data-testid=ticketbox-chkbox]').click();
+//     cy.get('[data-testid=ticketchoice-submitbtn]').click();
 
-    cy.get('[data-testid=steplist-step]').within(items => {
-      expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
-      expect(items[1]).to.have.css('color', 'rgb(65, 65, 65)');
-    });
-    cy.get('[data-testid=steplist-step-arrow]').within(items => {
-      expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
-    });
-  });
+//     cy.get('[data-testid=steplist-step]').within(items => {
+//       expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
+//       expect(items[1]).to.have.css('color', 'rgb(65, 65, 65)');
+//     });
+//     cy.get('[data-testid=steplist-step-arrow]').within(items => {
+//       expect(items[0]).to.have.css('color', 'rgb(65, 65, 65)');
+//     });
+//   });
 
-  it('로그인이 되어있지 않은 상태로 예약을 시도하면 alert와 login으로 리다이렉션이 이루어진다', () => {
-    cy.route({
-      method: 'POST',
-      url: '/api/users/reserve',
-      status: 401,
-      response: {},
-    });
+//   it('로그인이 되어있지 않은 상태로 예약을 시도하면 alert와 login으로 리다이렉션이 이루어진다', () => {
+//     cy.route({
+//       method: 'POST',
+//       url: '/api/users/reserve',
+//       status: 401,
+//       response: {},
+//     });
 
-    goPurchasePage();
+//     goPurchasePage();
 
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_REQUIRE_LOGIN);
-      });
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_REQUIRE_LOGIN);
+//       });
 
-    cy.location('pathname').should('eq', '/login');
-  });
+//     cy.location('pathname').should('eq', '/login');
+//   });
 
-  it('예약 응답이 NOT_FOUND 이라면 alert가 표시된다', () => {
-    cy.route({
-      method: 'POST',
-      url: '/api/users/reserve',
-      status: 404,
-      response: {},
-    });
+//   it('예약 응답이 NOT_FOUND 이라면 alert가 표시된다', () => {
+//     cy.route({
+//       method: 'POST',
+//       url: '/api/users/reserve',
+//       status: 404,
+//       response: {},
+//     });
 
-    goPurchasePage();
+//     goPurchasePage();
 
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_WRONG_NUMBER);
-      });
-  });
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_WRONG_NUMBER);
+//       });
+//   });
 
-  it('예약 응답이 FORBIDDEN / 유효하지 않은 일정이라면 alert가 표시된다', () => {
-    cy.route({
-      method: 'POST',
-      url: '/api/users/reserve',
-      status: 403,
-      response: { state: NOT_OPEN },
-    });
+//   it('예약 응답이 FORBIDDEN / 유효하지 않은 일정이라면 alert가 표시된다', () => {
+//     cy.route({
+//       method: 'POST',
+//       url: '/api/users/reserve',
+//       status: 403,
+//       response: { state: NOT_OPEN },
+//     });
 
-    goPurchasePage();
+//     goPurchasePage();
 
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_INVALID_DATE);
-      });
-  });
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_INVALID_DATE);
+//       });
+//   });
 
-  it('예약 응답이 FORBIDDEN / 매진이라면 alert가 표시된다', () => {
-    cy.route({
-      method: 'POST',
-      url: '/api/users/reserve',
-      status: 403,
-      response: { state: SOLD_OUT },
-    });
+//   it('예약 응답이 FORBIDDEN / 매진이라면 alert가 표시된다', () => {
+//     cy.route({
+//       method: 'POST',
+//       url: '/api/users/reserve',
+//       status: 403,
+//       response: { state: SOLD_OUT },
+//     });
 
-    goPurchasePage();
+//     goPurchasePage();
 
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_SOLD_OUT);
-      });
-  });
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_SOLD_OUT);
+//       });
+//   });
 
-  it('예약 응답이 FORBIDDEN / 1인당 티켓 개수 초과라면 alert가 표시된다', () => {
-    cy.route({
-      method: 'POST',
-      url: '/api/users/reserve',
-      status: 403,
-      response: { state: EXCEED_LIMIT },
-    });
+//   it('예약 응답이 FORBIDDEN / 1인당 티켓 개수 초과라면 alert가 표시된다', () => {
+//     cy.route({
+//       method: 'POST',
+//       url: '/api/users/reserve',
+//       status: 403,
+//       response: { state: EXCEED_LIMIT },
+//     });
 
-    goPurchasePage();
+//     goPurchasePage();
 
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_PER_PERSON_OVER);
-      });
-  });
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_PER_PERSON_OVER);
+//       });
+//   });
 
-  it('예약이 성공적으로 이루어지면 alert와 main으로 리다이렉션이 이루어진다', () => {
-    cy.route('POST', '/api/users/reserve', {});
+//   it('예약이 성공적으로 이루어지면 alert와 main으로 리다이렉션이 이루어진다', () => {
+//     cy.route('POST', '/api/users/reserve', {});
 
-    goPurchasePage();
-    const alertStub = cy.stub();
-    cy.on('window:alert', alertStub);
-    cy.get('[data-testid=ticketpurchase-purchasebtn]')
-      .click()
-      .then(() => {
-        expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_COMPLETE);
-      });
+//     goPurchasePage();
+//     const alertStub = cy.stub();
+//     cy.on('window:alert', alertStub);
+//     cy.get('[data-testid=ticketpurchase-purchasebtn]')
+//       .click()
+//       .then(() => {
+//         expect(alertStub.getCall(0)).to.be.calledWith(RESERVE_COMPLETE);
+//       });
 
-    cy.location('pathname').should('eq', '/my/tickets');
-  });
-});
+//     cy.location('pathname').should('eq', '/my/tickets');
+//   });
+// });

--- a/client/src/pages/EventDetail/index.tsx
+++ b/client/src/pages/EventDetail/index.tsx
@@ -41,13 +41,16 @@ const defaultEventDetail: EventDetail = {
 
 function EventDetailView(): React.ReactElement {
   window.scrollTo(0, 0);
-  const { eventId } = useParams();
   const remainDays = useRef(0);
   const history = useHistory();
   const [internalServerError, setInternalError] = useState(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [event, setEvent] = useState<EventDetail>(defaultEventDetail);
   const [fetchResult, fetchEvent] = useApiRequest<EventDetail>(getEvent);
+  const { eventId: originEventId } = useParams<{
+    eventId: string;
+  }>();
+  const eventId = +originEventId;
 
   useEffect(() => {
     fetchEvent({ type: 'REQUEST', body: [eventId] });

--- a/client/src/pages/EventJoin/index.tsx
+++ b/client/src/pages/EventJoin/index.tsx
@@ -1,12 +1,9 @@
-import React, { useState, useContext, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-
 import { UNAUTHORIZED, FORBIDDEN, NOT_FOUND } from 'http-status';
 import { useHistory } from 'react-router-dom';
 
-import { EventsStoreState, EventsStoreAction } from 'stores/eventsStore';
 import { EventDetail } from 'types/Data';
-
 import EventJoinTemplate from './template';
 import {
   Btn,
@@ -39,9 +36,10 @@ import {
 } from 'commons/constants/string';
 import { NOT_OPEN, SOLD_OUT, EXCEED_LIMIT } from 'commons/constants/number';
 import ROUTES from 'commons/constants/routes';
-import { joinEvent } from 'apis';
+import { joinEvent, getEvent } from 'apis';
 import { calculateStringOfDateRange } from 'utils/dateCalculator';
 import { getImageURL, imageTypes } from 'utils/getImageURL';
+import useApiRequest, { REQUEST, SUCCESS, FAILURE } from 'hooks/useApiRequest';
 
 const minTicketCount = 1;
 const steps = [JOIN_STEP_CHOICE, JOIN_STEP_PURCHASE];
@@ -77,86 +75,68 @@ const defaultEventData = {
 };
 
 function EventJoin(): React.ReactElement {
-  function getEventIfEventIsInState(
-    events: Map<number, EventDetail>,
-    eventId: number,
-  ) {
-    return events.get(eventId);
-  }
-
   const [isReserved, setisReserved] = useState(false);
   const [isTicketChecked, setIsTicketChecked] = useState(false);
   const [ticketCount, setTicketCount] = useState(1);
   const [templateStep, setTemplateStep] = useState(1);
-  const [eventState, setEventState] = useState(defaultEventData);
-  const eventsState = useContext(EventsStoreState);
-  const { eventFetchDispatcher } = useContext(EventsStoreAction);
 
   const history = useHistory();
-  const { eventId: originEventId } = useParams();
-  if (typeof originEventId === 'undefined') {
-    history.push('/404');
-  }
-  const getInEventState = useCallback(
-    (eventData: EventDetail) => {
-      setEventState(eventData);
-    },
-    [setEventState],
-  );
+  const { eventId: originEventId } = useParams<{
+    eventId: string;
+  }>();
 
-  const eventId = +originEventId!;
-  const { title, mainImg, startAt, endAt, user, ticketType } = eventState;
-  const { maxCntPerPerson } = ticketType;
-  const eventDataFromStore = getEventIfEventIsInState(
-    eventsState.events!,
-    eventId,
-  );
-  const isEventInState = !!eventDataFromStore;
-  const [isLoading, setLoading] = useState(true);
+  const eventId = +originEventId;
+
+  const [internalServerError, setInternalError] = useState(false);
+  const [isLoading, setLoading] = useState<boolean>(true);
+  const [event, setEvent] = useState<EventDetail>(defaultEventData);
+  const [fetchResult, fetchEvent] = useApiRequest<EventDetail>(getEvent);
 
   useEffect(() => {
-    if (isEventInState) {
-      getInEventState(eventDataFromStore!);
-      setLoading(false);
-      return;
-    }
+    fetchEvent({ type: 'REQUEST', body: [eventId] });
+  }, [fetchEvent, eventId]);
 
-    eventFetchDispatcher({
-      type: 'EVENT',
-      params: { eventId },
-    });
-    setLoading(false);
-  }, [
-    eventDataFromStore,
-    eventFetchDispatcher,
-    eventId,
-    eventsState,
-    getInEventState,
-    isEventInState,
-  ]);
+  useEffect(() => {
+    const { type, data, err } = fetchResult;
+    switch (type) {
+      case REQUEST:
+        break;
+      case SUCCESS:
+        if (data) {
+          setEvent(data);
+          setLoading(false);
+        }
+        break;
+      case FAILURE:
+        if (err && err.response && err.response.status === NOT_FOUND)
+          history.replace('/NOT_FOUND');
+        else if (err) setInternalError(true);
+    }
+  }, [fetchResult, history]);
+
+  const { title, mainImg, startAt, endAt, user, ticketType } = event;
+  const { maxCntPerPerson } = ticketType;
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  const isVisibleCounter = () => {
+  const isVisibleCounter = (): boolean => {
     return maxCntPerPerson > minTicketCount && isTicketChecked;
   };
 
-  const requestOrder = async () => {
+  const requestOrder = async (): Promise<void> => {
     if (!isTicketChecked || ticketCount <= 0) {
       return alert(RESERVE_REQUIRE_CHOICE);
     }
     setTemplateStep(templateStep + 1);
   };
 
-  const purchaseOrder = async () => {
-    if (isReserved) {
-      return;
-    }
-    if (ticketCount <= 0) {
-      return alert(RESERVE_MIN_FAIL);
-    }
+  const purchaseOrder = async (): Promise<void> => {
+    if (isReserved) return;
+
+    if (ticketCount <= 0) return alert(RESERVE_MIN_FAIL);
+
     try {
       await joinEvent(eventId, ticketCount);
       setisReserved(true);
@@ -201,6 +181,7 @@ function EventJoin(): React.ReactElement {
     <EventJoinTemplate
       step={templateStep}
       loading={isLoading}
+      internalServerError={internalServerError}
       stepList={<StepList steps={steps} pivot={templateStep} />}
       eventSection={
         <EventSection
@@ -213,7 +194,7 @@ function EventJoin(): React.ReactElement {
           imgSrc={getImageURL(mainImg, imageTypes.eventDetailRegisterImg)}
         />
       }
-      place={<Place mapHeight={'20rem'} {...eventState} />}
+      place={<Place mapHeight={'20rem'} {...event} />}
       ticketChoiceProps={{
         header: TICKET_CHOICE_TITLE,
         ticketBox: (
@@ -221,9 +202,7 @@ function EventJoin(): React.ReactElement {
             {...ticketType}
             chkProps={{
               checked: isTicketChecked,
-              onClick: () => {
-                setIsTicketChecked(!isTicketChecked);
-              },
+              onClick: (): void => setIsTicketChecked(!isTicketChecked),
             }}
             showDueDate
           />

--- a/client/src/pages/EventJoin/template/index.tsx
+++ b/client/src/pages/EventJoin/template/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   ticketChoiceProps: TicketChoiceProps;
   ticketPurchaseProps: TicketPurchaseProps;
   loading: boolean;
+  internalServerError: boolean;
 }
 
 const TICKET_CHOICE_STEP = 1;


### PR DESCRIPTION
### 관련 이슈

#462 이벤트 디테일/조인 페이지에서 무조건 API 콜하기

### 변경 사항 및 이유

토의한 결과물입니다. 
글로벌 스토어를 사용하던 것을 걷어내었습니다!
ONLY API CALL, NO USE STORE

### PR Point
@doong-jo useParams에도 타입을 지정해서 받을 수가 있네요!
```typescript
  const { eventId: originEventId } = useParams<{
    eventId: string;
  }>();
  const eventId = +originEventId;
```

### 참고 사항

EventJoin Page에서 빌드에러가 발생해서, @doong-jo 님 Approve받고 임시로 제거했습니다.

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
