### PR TITLE
[PR] 이벤트 만들기 API 리턴값 수정 

### DIFF
--- a/server/src/routes/api/events/controllers/createEvent.ts
+++ b/server/src/routes/api/events/controllers/createEvent.ts
@@ -1,15 +1,18 @@
 import { Request, Response, NextFunction } from 'express';
-import { createEventAndTicket } from 'services/events';
+import { createEventAndTicket, getEventById } from 'services/events';
 import { putObject } from 'utils/awsS3';
 import { Event, TicketType } from 'models';
 import { v1 as uuid } from 'uuid';
 import { CREATED } from 'http-status';
-
 interface Body extends Partial<Event> {
   ticket: Partial<TicketType>;
 }
 
-export default async (req: Request, res: Response, next: NextFunction) => {
+export default async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
   const {
     isPublic,
     title,
@@ -70,8 +73,9 @@ export default async (req: Request, res: Response, next: NextFunction) => {
   try {
     event.userId = req.user?.id;
     event.mainImg = mainImageKey;
-    const { eventId, ticketId } = await createEventAndTicket(event, ticketType);
-    res.status(CREATED).json({ eventId, ticketId });
+    const { eventId } = await createEventAndTicket(event, ticketType);
+    const data = await getEventById(eventId);
+    res.status(CREATED).json(data);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
### 관련 이슈

#490 이벤트 만들기 리턴값 수정 

### 변경 사항 및 이유

이벤트 만들기 API가 기존에는 ticketId, eventId만 리턴해주었는데 정보를 모두 반환하도록 설계

### PR Point

없음

### 참고 사항

테스트 코드의 수정은 필요없습니다.

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [x] 테스트를 돌려보셨나요? 🙆‍♂️
- [x] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
