### PR TITLE
[PR] Cypress에서의 스크롤 이벤트 wait를 낭낭하게 주었습니다.

### DIFF
--- a/client/cypress/integration/main.spec.ts
+++ b/client/cypress/integration/main.spec.ts
@@ -29,6 +29,7 @@ context('메인 페이지', () => {
     cy.scrollTo('bottom');
     cy.wait('@getEventsMore');
 
+    cy.wait(5000);
     cy.get('[data-testid=main-card]', { timeout: 3000 }).within(items => {
       expect(items).to.have.length(24);
     });


### PR DESCRIPTION
# Explanation

컴퓨팅 성능에 따라 테스트가 복불복이어서 wait을 주었습니다.