### PR TITLE
[PR] 이미지 셀렉터 파일 재선택시 취소 눌렀을 때 에러 처리

### DIFF
--- a/client/src/components/atoms/ImgSelector/index.tsx
+++ b/client/src/components/atoms/ImgSelector/index.tsx
@@ -33,6 +33,9 @@ function readFileOfInput(
       return reject(new Error(FILE_NOT_FOUND_ERROR_INFO));
 
     const file: File = inputRef.current.files[0];
+
+    if (!file) return reject(new Error('NO FILE SELECTED'));
+
     if (!file.type.startsWith('image')) {
       clearFileInput(inputRef);
       return reject(new Error(ONLY_IMG_FILE_INFO));
@@ -67,6 +70,7 @@ function ImgSelector({
       setBackground(data);
       onChange && onChange(data, file);
     } catch (error) {
+      if (error.message === 'NO FILE SELECTED') return;
       alert(error.message);
     }
   }, [inputRef, onChange, maxSize]);


### PR DESCRIPTION
### 관련 이슈
#503 

### 변경 사항 및 이유
파일 선택 후 파일 재선택 시 파일 다이얼로그를 취소해도
onChange 이벤트가 발생하여 file 이 들어오지 않던 버그를 고침

### PR Point


### 참고 사항

<!— 참고할 사항이 있다면 적어주세요. —>

### Check Point

- [ ] 테스트는 작성하셨나요? 👀
- [ ] 테스트를 돌려보셨나요? 🙆‍♂️
- [ ] 빌드를 직접해서 올려보셨나요? 🙆‍♀️
- [x] 사용하지 않는 변수, import, 함수 등은 없나요? 🙅‍♂️
